### PR TITLE
Inject content scripts dynamically

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"react-router-dom": "^5.2.0",
 		"rollbar": "^2.19.3",
 		"typeface-roboto": "^0.0.75",
-		"webextension-polyfill": "^0.6.0"
+		"webextension-polyfill": "^0.8.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ dependencies:
   react-router-dom: 5.2.0_react@16.13.1
   rollbar: 2.19.3
   typeface-roboto: 0.0.75
-  webextension-polyfill: 0.6.0
+  webextension-polyfill: 0.8.0
 devDependencies:
   '@babel/core': 7.11.4
   '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.4
@@ -8935,10 +8935,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-oQZYDU3W8X867h8Jmt3129kRVKklz70db40Y6OzoTTuzOJpF/dB2KULJUf0txVPyUUXuyzV8GmT3nVvRHoG+Ew==
-  /webextension-polyfill/0.6.0:
+  /webextension-polyfill/0.8.0:
     dev: false
     resolution:
-      integrity: sha512-PlYwiX8e4bNZrEeBFxbFFsLtm0SMPxJliLTGdNCA0Bq2XkWrAn2ejUd+89vZm+8BnfFB1BclJyCz3iKsm2atNg==
+      integrity: sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==
   /webpack-cli/3.3.12_webpack@4.44.1:
     dependencies:
       chalk: 2.4.2
@@ -9246,6 +9246,6 @@ specifiers:
   typeface-roboto: ^0.0.75
   typescript: ^4.0.2
   web-ext-types: ^3.2.1
-  webextension-polyfill: ^0.6.0
+  webextension-polyfill: ^0.8.0
   webpack: ^4.44.1
   webpack-cli: ^3.3.12

--- a/src/common/Messaging.ts
+++ b/src/common/Messaging.ts
@@ -1,14 +1,7 @@
 import { Item } from '../models/Item';
-import { GetCacheMessage, GetTabIdMessage, MessageRequest } from '../modules/background/background';
-import { CacheValues } from './Cache';
+import { MessageRequest, ReturnTypes } from '../modules/background/background';
 import { Errors } from './Errors';
 import { EventDispatcher } from './Events';
-
-export type ReturnTypes<T extends MessageRequest> = T extends GetTabIdMessage
-	? { tabId: number | undefined }
-	: T extends GetCacheMessage
-	? CacheValues[keyof CacheValues]
-	: Record<string, unknown>;
 
 class _Messaging {
 	startListeners = () => {
@@ -47,9 +40,11 @@ class _Messaging {
 		});
 	};
 
-	toBackground = async <T extends MessageRequest>(message: T): Promise<ReturnTypes<T>> => {
+	toBackground = async <T extends MessageRequest>(
+		message: T
+	): Promise<ReturnTypes[T['action']]> => {
 		const response: string = await browser.runtime.sendMessage(JSON.stringify(message));
-		return JSON.parse(response) as ReturnTypes<T>;
+		return JSON.parse(response) as ReturnTypes[T['action']];
 	};
 
 	toContent = async (message: MessageRequest, tabId: number): Promise<void> => {

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -49,9 +49,8 @@ class _Requests {
 			responseText = await this.sendDirectly(request, tabId);
 		} else {
 			const response = await Messaging.toBackground({ action: 'send-request', request });
-			responseText = (response as unknown) as string;
-			if (response.error) {
-				throw response.error;
+			if (response) {
+				responseText = response;
 			}
 		}
 		return responseText;

--- a/src/common/Tabs.ts
+++ b/src/common/Tabs.ts
@@ -19,7 +19,7 @@ class _Tabs {
 	open = async (
 		url: string,
 		extraProperties: TabProperties = {}
-	): Promise<browser.tabs.Tab | undefined> => {
+	): Promise<browser.tabs.Tab | null> => {
 		if (Shared.pageType === 'content') {
 			return Messaging.toBackground({
 				action: 'open-tab',
@@ -29,7 +29,7 @@ class _Tabs {
 		}
 		const tabs = await browser.tabs.query({ active: true, currentWindow: true });
 		if (tabs.length === 0) {
-			return;
+			return null;
 		}
 		const tabProperties: TabProperties = {
 			index: tabs[0].index + 1,

--- a/src/common/Tabs.ts
+++ b/src/common/Tabs.ts
@@ -1,4 +1,6 @@
 import { BrowserStorage } from './BrowserStorage';
+import { Messaging } from './Messaging';
+import { Shared } from './Shared';
 
 export interface TabProperties {
 	active?: boolean;
@@ -18,6 +20,13 @@ class _Tabs {
 		url: string,
 		extraProperties: TabProperties = {}
 	): Promise<browser.tabs.Tab | undefined> => {
+		if (Shared.pageType === 'content') {
+			return Messaging.toBackground({
+				action: 'open-tab',
+				url,
+				extraProperties,
+			});
+		}
 		const tabs = await browser.tabs.query({ active: true, currentWindow: true });
 		if (tabs.length === 0) {
 			return;

--- a/src/modules/background/background.ts
+++ b/src/modules/background/background.ts
@@ -1,4 +1,4 @@
-import { TraktAuth } from '../../api/TraktAuth';
+import { TraktAuth, TraktAuthDetails } from '../../api/TraktAuth';
 import { TraktScrobble } from '../../api/TraktScrobble';
 import { WrongItemApi } from '../../api/WrongItemApi';
 import { BrowserAction } from '../../common/BrowserAction';
@@ -28,6 +28,27 @@ export type MessageRequest =
 	| ShowNotificationMessage
 	| WrongItemCorrectedMessage
 	| SaveCorrectionSuggestionMessage;
+
+export type ReturnTypes = {
+	'get-tab-id': {
+		tabId?: number;
+	};
+	'check-login': TraktAuthDetails;
+	'finish-login': null;
+	login: TraktAuthDetails;
+	logout: null;
+	'get-cache': CacheValues[keyof CacheValues];
+	'set-cache': null;
+	'set-active-icon': null;
+	'set-inactive-icon': null;
+	'check-scrobble': null;
+	'start-scrobble': null;
+	'stop-scrobble': null;
+	'send-request': string;
+	'show-notification': string;
+	'wrong-item-corrected': null;
+	'save-correction-suggestion': null;
+};
 
 export interface GetTabIdMessage {
 	action: 'get-tab-id';

--- a/src/modules/background/background.ts
+++ b/src/modules/background/background.ts
@@ -7,11 +7,13 @@ import { Cache, CacheValues } from '../../common/Cache';
 import { Errors } from '../../common/Errors';
 import { RequestDetails, Requests } from '../../common/Requests';
 import { Shared } from '../../common/Shared';
+import { TabProperties, Tabs } from '../../common/Tabs';
 import { Item } from '../../models/Item';
 import { TraktItem } from '../../models/TraktItem';
 import { StreamingServiceId, streamingServices } from '../../streaming-services/streaming-services';
 
 export type MessageRequest =
+	| OpenTabMessage
 	| GetTabIdMessage
 	| CheckLoginMessage
 	| FinishLoginMessage
@@ -30,6 +32,7 @@ export type MessageRequest =
 	| SaveCorrectionSuggestionMessage;
 
 export type ReturnTypes = {
+	'open-tab': browser.tabs.Tab;
 	'get-tab-id': {
 		tabId?: number;
 	};
@@ -49,6 +52,12 @@ export type ReturnTypes = {
 	'wrong-item-corrected': null;
 	'save-correction-suggestion': null;
 };
+
+export interface OpenTabMessage {
+	action: 'open-tab';
+	url: string;
+	extraProperties?: TabProperties;
+}
 
 export interface GetTabIdMessage {
 	action: 'get-tab-id';
@@ -361,6 +370,10 @@ const onMessage = (request: string, sender: browser.runtime.MessageSender): Prom
 	let executingAction: Promise<unknown>;
 	const parsedRequest = JSON.parse(request) as MessageRequest;
 	switch (parsedRequest.action) {
+		case 'open-tab': {
+			executingAction = Tabs.open(parsedRequest.url, parsedRequest.extraProperties);
+			break;
+		}
 		case 'get-tab-id': {
 			executingAction = Promise.resolve({ tabId: sender.tab?.id });
 			break;

--- a/src/modules/background/background.ts
+++ b/src/modules/background/background.ts
@@ -31,7 +31,7 @@ export type MessageRequest =
 	| WrongItemCorrectedMessage
 	| SaveCorrectionSuggestionMessage;
 
-export type ReturnTypes = {
+export interface ReturnTypes {
 	'open-tab': browser.tabs.Tab;
 	'get-tab-id': {
 		tabId?: number;
@@ -51,7 +51,13 @@ export type ReturnTypes = {
 	'show-notification': string;
 	'wrong-item-corrected': null;
 	'save-correction-suggestion': null;
-};
+}
+
+export interface ErrorReturnType {
+	error: {
+		message: string;
+	};
+}
 
 export interface OpenTabMessage {
 	action: 'open-tab';
@@ -465,7 +471,7 @@ const onMessage = (request: string, sender: browser.runtime.MessageSender): Prom
 				Errors.log('Failed to execute action.', err);
 				resolve(
 					JSON.stringify({
-						error: err.message ? { message: err.message } : err,
+						error: { message: err.message },
 					})
 				);
 			});

--- a/src/modules/history/history.tsx
+++ b/src/modules/history/history.tsx
@@ -12,7 +12,7 @@ import { HistoryApp } from './HistoryApp';
 
 const init = async () => {
 	Shared.pageType = 'popup';
-	Shared.tabId = (await Messaging.toBackground({ action: 'get-tab-id' })).tabId;
+	Shared.tabId = (await Messaging.toBackground({ action: 'get-tab-id' }))?.tabId;
 	await BrowserStorage.sync();
 	const values = await BrowserStorage.get('options');
 	if (values.options && values.options.allowRollbar) {

--- a/src/modules/options/OptionsApp.tsx
+++ b/src/modules/options/OptionsApp.tsx
@@ -139,7 +139,7 @@ export const OptionsApp: React.FC = () => {
 			if (originsToAdd.length > 0) {
 				permissionPromises.push(
 					browser.permissions.request({
-						permissions: scrobblerEnabled ? ['webNavigation'] : [],
+						permissions: scrobblerEnabled ? ['tabs', 'webNavigation'] : [],
 						origins: originsToAdd,
 					})
 				);
@@ -147,7 +147,7 @@ export const OptionsApp: React.FC = () => {
 			if (originsToRemove.length > 0) {
 				permissionPromises.push(
 					browser.permissions.remove({
-						permissions: scrobblerEnabled ? [] : ['webNavigation'],
+						permissions: scrobblerEnabled ? [] : ['tabs', 'webNavigation'],
 						origins: originsToRemove,
 					})
 				);

--- a/src/modules/options/OptionsApp.tsx
+++ b/src/modules/options/OptionsApp.tsx
@@ -129,11 +129,17 @@ export const OptionsApp: React.FC = () => {
 			for (const option of Object.values(options) as Option<keyof StorageValuesOptions>[]) {
 				addOptionToSave(optionsToSave, option);
 			}
+			const scrobblerEnabled = (Object.entries(optionsToSave.streamingServices) as [
+				StreamingServiceId,
+				boolean
+			][]).some(
+				([streamingServiceId, value]) => value && streamingServices[streamingServiceId].hasScrobbler
+			);
 			const permissionPromises: Promise<boolean>[] = [];
 			if (originsToAdd.length > 0) {
 				permissionPromises.push(
 					browser.permissions.request({
-						permissions: [],
+						permissions: scrobblerEnabled ? ['webNavigation'] : [],
 						origins: originsToAdd,
 					})
 				);
@@ -141,7 +147,7 @@ export const OptionsApp: React.FC = () => {
 			if (originsToRemove.length > 0) {
 				permissionPromises.push(
 					browser.permissions.remove({
-						permissions: [],
+						permissions: scrobblerEnabled ? [] : ['webNavigation'],
 						origins: originsToRemove,
 					})
 				);

--- a/src/streaming-services/common/ScrobbleController.ts
+++ b/src/streaming-services/common/ScrobbleController.ts
@@ -112,15 +112,12 @@ export class ScrobbleController {
 		});
 		await this.onStart();
 		try {
-			const response = await Messaging.toBackground({
+			await Messaging.toBackground({
 				action: 'save-correction-suggestion',
 				serviceId: this.item.serviceId,
 				item: this.item,
 				url: data.url,
 			});
-			if (response?.error) {
-				throw response.error;
-			}
 		} catch (err) {
 			if (!(err as RequestException).canceled) {
 				Errors.error('Failed to save suggestion.', err);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -201,6 +201,7 @@ const getManifest = (config: Config, browserName: string): string => {
 		optional_permissions: [
 			'cookies',
 			'notifications',
+			'tabs',
 			'webNavigation',
 			'webRequest',
 			'webRequestBlocking',
@@ -219,7 +220,7 @@ const getManifest = (config: Config, browserName: string): string => {
 			default_popup: 'html/popup.html',
 			default_title: 'Universal Trakt Scrobbler',
 		},
-		permissions: ['identity', 'storage', 'tabs', 'unlimitedStorage', '*://*.trakt.tv/*'],
+		permissions: ['identity', 'storage', 'unlimitedStorage', '*://*.trakt.tv/*'],
 		web_accessible_resources: [
 			'images/uts-icon-38.png',
 			'images/uts-icon-selected-38.png',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -177,13 +177,6 @@ const getWebpackConfig = (env: Environment) => {
 };
 
 const getManifest = (config: Config, browserName: string): string => {
-	const streamingServiceScripts: Manifest['content_scripts'] = Object.values(streamingServices)
-		.filter((service) => service.hasScrobbler)
-		.map((service) => ({
-			js: ['js/lib/browser-polyfill.js', `js/${service.id}.js`],
-			matches: service.hostPatterns,
-			run_at: 'document_idle',
-		}));
 	const manifest: Manifest = {
 		manifest_version: 2,
 		name: 'Universal Trakt Scrobbler',
@@ -203,12 +196,12 @@ const getManifest = (config: Config, browserName: string): string => {
 				matches: ['*://*.trakt.tv/apps*'],
 				run_at: 'document_start',
 			},
-			...streamingServiceScripts,
 		],
 		default_locale: 'en',
 		optional_permissions: [
 			'cookies',
 			'notifications',
+			'webNavigation',
 			'webRequest',
 			'webRequestBlocking',
 			'*://api.rollbar.com/*',


### PR DESCRIPTION
Fixes #51 

This was a tough one to fix, because `browser.tabs.onUpdated` is triggered multiple times for the same tab, and it's triggered even more by single-page apps like Netflix, so initially I couldn't figure out how to differentiate between a page load and a reload without resulting in duplicate injections.

Then I found out about `browser.webNavigation.onCommitted`, which allows detecting page loads / reloads and is only triggered once. However, the ability to detect page loads is not supported by Firefox, so I ended up having to use `browser.tabs.onUpdated` to detect page loads and `browser.webNavigation.onCommitted` to detect reloads.

A bit complex, but seems to be working well.

Will rebase once #49 is merged.