### PR TITLE
Temporary fix Amazon Prime EU (+global?) - removal of api usage

### DIFF
--- a/src/services/amazon-prime-eu/AmazonPrimeEuApi.ts
+++ b/src/services/amazon-prime-eu/AmazonPrimeEuApi.ts
@@ -1,0 +1,10 @@
+import { AmazonPrimeEuService } from '@/amazon-prime-eu/AmazonPrimeEuService';
+import { ServiceApi } from '@apis/ServiceApi';
+
+class _AmazonPrimeEuApi extends ServiceApi {
+	constructor() {
+		super(AmazonPrimeEuService.id);
+	}
+}
+
+export const AmazonPrimeEuApi = new _AmazonPrimeEuApi();

--- a/src/services/amazon-prime-eu/AmazonPrimeEuParser.ts
+++ b/src/services/amazon-prime-eu/AmazonPrimeEuParser.ts
@@ -1,0 +1,52 @@
+import { AmazonPrimeEuApi } from '@/amazon-prime-eu/AmazonPrimeEuApi';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { Item } from '@models/Item';
+
+class _AmazonPrimeEuParser extends ScrobbleParser {
+	constructor() {
+		super(AmazonPrimeEuApi, {
+			watchingUrlRegex: /\/detail\/(.+)/, // https://www.primevideo.com/detail/0SXLM6OIAQ0DUSWD1815OYS4EY/ref=atv_hm_hom_c_7d0kid_4_1
+		});
+	}
+
+	parseItemFromDom() {
+		const serviceId = this.api.id;
+		const id = this.parseItemIdFromUrl();
+		const titleElement = document.querySelector('.atvwebplayersdk-title-text');
+		const title = titleElement?.textContent?.split(':')[0].toString() ?? '';
+		const subTitleElement = document.querySelector('.atvwebplayersdk-subtitle-text');
+		const type = subTitleElement?.textContent ? 'show' : 'movie';
+
+		let seasonAndEpisode: string | null = null;
+		let seasonStr: string | null = null;
+		let episodeStr: string | null = null;
+		let subTitle: string | undefined = undefined;
+
+		// Shows get a subtitle like this (dutch example): "S1: afl. 6 One World, One People"
+		const matches = /(.+?(\d+).+?(\d+) )?(.+)/.exec(subTitleElement?.textContent ?? '');
+
+		if (matches) {
+			[, seasonAndEpisode, seasonStr, episodeStr, subTitle] = matches;
+		}
+
+		const season = seasonAndEpisode ? parseInt(seasonStr ?? '') : undefined;
+		const episode = seasonAndEpisode ? parseInt(episodeStr ?? '') : undefined;
+		const episodeTitle = subTitle ?? '';
+
+		if (!titleElement) {
+			return null;
+		}
+
+		return new Item({
+			serviceId,
+			id,
+			type,
+			title,
+			episodeTitle,
+			season,
+			episode,
+		});
+	}
+}
+
+export const AmazonPrimeEuParser = new _AmazonPrimeEuParser();

--- a/src/services/amazon-prime-eu/AmazonPrimeEuService.ts
+++ b/src/services/amazon-prime-eu/AmazonPrimeEuService.ts
@@ -1,0 +1,11 @@
+import { Service } from '@models/Service';
+
+export const AmazonPrimeEuService = new Service({
+	id: 'amazon-prime-eu',
+	name: 'AmazonPrimeEu',
+	homePage: 'https://www.primevideo.com/',
+	hostPatterns: ['*://*.primevideo.com/*'],
+	hasScrobbler: true,
+	hasSync: false,
+	hasAutoSync: false,
+});

--- a/src/services/amazon-prime-eu/amazon-prime-eu.ts
+++ b/src/services/amazon-prime-eu/amazon-prime-eu.ts
@@ -1,0 +1,4 @@
+import '@/amazon-prime-eu/AmazonPrimeEuParser';
+import { init } from '@service';
+
+void init('amazon-prime-eu');


### PR DESCRIPTION
Added a service for Amazon Prime EU. Just using the same way the other services work.
Still needs fix for history sync, but not sure how we can solve this so both the EU and American version works

By the way, is there an option to add names to the "suggestion" list?
Shameless is called "Shameless: the complete series", but can't be found that way. I fixed it at this moment with splitting the title. But that's not best practice :)