### PR TITLE
Fix bug that happens on Netflix when parsing some items

### DIFF
--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -267,8 +267,7 @@ class _NetflixApi extends ServiceApi {
 			let season;
 			let episode;
 			const isCollection = !historyItem.seasonDescriptor.includes('Season');
-			if (!isCollection) {
-				// TODO: Some items don't have a summary response (see Friends pilot).
+			if (!isCollection && historyItem.summary) {
 				season = historyItem.summary.season;
 				episode = historyItem.summary.episode;
 			}


### PR DESCRIPTION
We can just ignore items that don't have a `summary`, since they'll be matched by episode title anyway.