### PR TITLE
Change order of dialogs

### DIFF
--- a/src/modules/history/HistoryApp.tsx
+++ b/src/modules/history/HistoryApp.tsx
@@ -4,6 +4,7 @@ import { HistoryContainer } from '@components/HistoryContainer';
 import { HistoryHeader } from '@components/HistoryHeader';
 import { LoginWrapper } from '@components/LoginWrapper';
 import { ServiceLoginWrapper } from '@components/ServiceLoginWrapper';
+import { SyncDialog } from '@components/SyncDialog';
 import { useHistory } from '@contexts/HistoryContext';
 import { SyncProvider } from '@contexts/SyncContext';
 import { getServices } from '@models/Service';
@@ -20,6 +21,8 @@ export const HistoryApp = (): JSX.Element => {
 
 	return (
 		<>
+			<CustomDialog />
+			<CustomSnackbar />
 			<Router history={history}>
 				<Switch>
 					<Route
@@ -64,6 +67,7 @@ export const HistoryApp = (): JSX.Element => {
 								render={() => (
 									<LoginWrapper>
 										<SyncProvider serviceId={service.id}>
+											<SyncDialog />
 											<ServiceLoginWrapper>
 												<HistoryHeader />
 												<HistoryContainer isSync={true} disableGutters={true} maxWidth={false}>
@@ -91,8 +95,6 @@ export const HistoryApp = (): JSX.Element => {
 					<Redirect to="/login" />
 				</Switch>
 			</Router>
-			<CustomDialog />
-			<CustomSnackbar />
 		</>
 	);
 };

--- a/src/modules/history/pages/SyncPage.tsx
+++ b/src/modules/history/pages/SyncPage.tsx
@@ -3,17 +3,15 @@ import { HistoryActions } from '@components/HistoryActions';
 import { HistoryList } from '@components/HistoryList';
 import { HistoryOptionsList } from '@components/HistoryOptionsList';
 import { MissingWatchedDateDialog } from '@components/MissingWatchedDateDialog';
-import { SyncDialog } from '@components/SyncDialog';
 
 export const SyncPage = (): JSX.Element => {
 	return (
 		<>
+			<MissingWatchedDateDialog />
+			<CorrectionDialog />
 			<HistoryOptionsList />
 			<HistoryList />
 			<HistoryActions />
-			<SyncDialog />
-			<MissingWatchedDateDialog />
-			<CorrectionDialog />
 		</>
 	);
 };


### PR DESCRIPTION
Dialogs should be rendered before everything else, so they can start listening to events instantly.