### PR TITLE
Cancel requests from a tab when it closes

### DIFF
--- a/src/common/Events.ts
+++ b/src/common/Events.ts
@@ -120,6 +120,7 @@ export interface HistorySyncSuccessData {
 }
 
 export interface RequestsCancelData {
+	tabId: number | null;
 	key: string;
 }
 

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -93,7 +93,7 @@ class _Requests {
 
 	async fetch(request: RequestDetails, tabId = Shared.tabId): Promise<AxiosResponse<string>> {
 		const options = await this.getOptions(request, tabId);
-		const cancelKey = request.cancelKey || 'default';
+		const cancelKey = `${tabId !== null ? `${tabId}_` : ''}${request.cancelKey || 'default'}`;
 		if (!RequestsManager.abortControllers.has(cancelKey)) {
 			RequestsManager.abortControllers.set(cancelKey, new AbortController());
 		}

--- a/src/components/SyncDialog.tsx
+++ b/src/components/SyncDialog.tsx
@@ -18,7 +18,10 @@ export const SyncDialog = (): JSX.Element => {
 	};
 
 	const cancelSync = async () => {
-		await Shared.events.dispatch('REQUESTS_CANCEL', null, { key: 'sync' });
+		await Shared.events.dispatch('REQUESTS_CANCEL', null, {
+			tabId: Shared.tabId,
+			key: 'sync',
+		});
 		closeDialog();
 	};
 

--- a/src/modules/history/components/HistoryList.tsx
+++ b/src/modules/history/components/HistoryList.tsx
@@ -256,7 +256,10 @@ export const HistoryList = (): JSX.Element => {
 			Shared.events.unsubscribe('ITEMS_LOAD', null, onItemsLoad);
 			Shared.events.unsubscribe('SYNC_STORE_RESET', null, checkEnd);
 
-			void Shared.events.dispatch('REQUESTS_CANCEL', null, { key: 'default' });
+			void Shared.events.dispatch('REQUESTS_CANCEL', null, {
+				tabId: Shared.tabId,
+				key: 'default',
+			});
 		};
 
 		const onHistoryLoadError = async () => {


### PR DESCRIPTION
Right now if you close a tab, any requests that were queued from it will continue to run. This fixes that, by adding the tab ID to the cancel key and subscribing to the `browser.tabs.onTabRemoved` listener. So now whenever a tab closes all requests that were queued from it are canceled.