### PR TITLE
Split Item and TraktItem models

### DIFF
--- a/src/apis/CorrectionApi.ts
+++ b/src/apis/CorrectionApi.ts
@@ -1,7 +1,7 @@
 import { Cache } from '@common/Cache';
 import { Requests } from '@common/Requests';
 import { Shared } from '@common/Shared';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 
 export interface Suggestion {
 	type: 'episode' | 'movie';
@@ -43,7 +43,7 @@ class _CorrectionApi {
 	 *
 	 * If all suggestions have already been loaded, returns the same parameter array, otherwise returns a new array for immutability.
 	 */
-	async loadSuggestions(items: Item[]): Promise<Item[]> {
+	async loadSuggestions(items: ScrobbleItem[]): Promise<ScrobbleItem[]> {
 		if (!Shared.storage.options.sendReceiveSuggestions) {
 			return items;
 		}
@@ -54,7 +54,7 @@ class _CorrectionApi {
 		const newItems = items.map((item) => item.clone());
 		const cache = await Cache.get('suggestions');
 		try {
-			const itemsToFetch: Item[] = [];
+			const itemsToFetch: ScrobbleItem[] = [];
 			for (const item of newItems) {
 				if (typeof item.suggestions !== 'undefined') {
 					continue;
@@ -108,7 +108,7 @@ class _CorrectionApi {
 	/**
 	 * Saves a suggestion for an item in the database.
 	 */
-	async saveSuggestion(item: Item, suggestion: Suggestion): Promise<void> {
+	async saveSuggestion(item: ScrobbleItem, suggestion: Suggestion): Promise<void> {
 		if (!Shared.storage.options.sendReceiveSuggestions) {
 			return;
 		}

--- a/src/apis/TraktApi.ts
+++ b/src/apis/TraktApi.ts
@@ -44,7 +44,7 @@ export class TraktApi {
 		this.SETTINGS_URL = `${this.API_URL}/users/settings`;
 	}
 
-	async activate() {
+	async activate(): Promise<void> {
 		if (this.isActivated) {
 			return;
 		}

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -4,7 +4,7 @@ import { CacheItems } from '@common/Cache';
 import { RequestError } from '@common/RequestError';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { EpisodeItem, isItem, ScrobbleItem } from '@models/Item';
+import { EpisodeItem, isItem, Item, ScrobbleItem } from '@models/Item';
 import {
 	createTraktScrobbleItem,
 	TraktEpisodeItem,
@@ -187,7 +187,7 @@ class _TraktSearch extends TraktApi {
 		}
 	}
 
-	async findItem(item: ScrobbleItem, cancelKey = 'default'): Promise<TraktSearchItem> {
+	async findItem(item: Item, cancelKey = 'default'): Promise<TraktSearchItem> {
 		let searchItem: TraktSearchItem | undefined;
 		await this.activate();
 		const responseText = await this.requests.send({
@@ -242,7 +242,7 @@ class _TraktSearch extends TraktApi {
 		if (!cacheItem) {
 			let show;
 			if (isItem(itemOrUrl)) {
-				show = ((await this.findItem(itemOrUrl, cancelKey)) as TraktSearchShowItem).show;
+				show = ((await this.findItem(itemOrUrl.show, cancelKey)) as TraktSearchShowItem).show;
 			} else {
 				await this.activate();
 				const showResponse = await this.requests.send({

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -4,14 +4,20 @@ import { CacheItems } from '@common/Cache';
 import { RequestError } from '@common/RequestError';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { Item } from '@models/Item';
-import { TraktItem } from '@models/TraktItem';
+import { EpisodeItem, isItem, ScrobbleItem } from '@models/Item';
+import {
+	createTraktScrobbleItem,
+	TraktEpisodeItem,
+	TraktMovieItem,
+	TraktScrobbleItem,
+	TraktShowItemValues,
+} from '@models/TraktItem';
 
 export type TraktSearchItem = TraktSearchShowItem | TraktSearchMovieItem;
 
-export type TraktSearchEpisodeItem = TraktEpisodeItem & TraktSearchShowItem;
+export type TraktSearchEpisodeItem = TraktSearchEpisodeItemEpisode & TraktSearchShowItem;
 
-export interface TraktEpisodeItem {
+export interface TraktSearchEpisodeItemEpisode {
 	episode: TraktEpisodeItemEpisode;
 }
 
@@ -70,12 +76,12 @@ class _TraktSearch extends TraktApi {
 	}
 
 	async find(
-		item: Item,
+		item: ScrobbleItem,
 		caches: CacheItems<['itemsToTraktItems', 'traktItems', 'urlsToTraktItems']>,
 		exactItemDetails?: ExactItemDetails,
 		cancelKey = 'default'
-	): Promise<TraktItem | null> {
-		let traktItem: TraktItem | null = null;
+	): Promise<TraktScrobbleItem | null> {
+		let traktItem: TraktScrobbleItem | null = null;
 		const databaseId = item.getDatabaseId();
 		let traktDatabaseId = exactItemDetails
 			? 'id' in exactItemDetails
@@ -83,53 +89,47 @@ class _TraktSearch extends TraktApi {
 				: caches.urlsToTraktItems.get(exactItemDetails.url)
 			: caches.itemsToTraktItems.get(databaseId);
 		const cacheItem = traktDatabaseId ? caches.traktItems.get(traktDatabaseId) : null;
-		if (cacheItem) {
-			traktItem = TraktItem.load(cacheItem);
+		if (cacheItem && cacheItem.type !== 'show') {
+			traktItem = createTraktScrobbleItem(cacheItem);
 			return traktItem;
 		}
 		try {
 			let searchItem: TraktSearchEpisodeItem | TraktSearchMovieItem;
 			if (exactItemDetails) {
 				searchItem = await this.findExactItem(exactItemDetails, caches, cancelKey);
-			} else if (item.type === 'show') {
+			} else if (item.type === 'episode') {
 				searchItem = await this.findEpisode(item, caches, cancelKey);
 			} else {
 				searchItem = (await this.findItem(item, cancelKey)) as TraktSearchMovieItem;
 			}
 			if ('episode' in searchItem) {
-				const id = searchItem.episode.ids.trakt;
-				const tmdbId = searchItem.show.ids.tmdb;
-				const title = searchItem.show.title;
-				const year = searchItem.show.year;
-				const season = searchItem.episode.season;
-				const episode = searchItem.episode.number;
-				const episodeTitle = searchItem.episode.title;
-				const firstAired = searchItem.episode.first_aired;
+				const { episode, show } = searchItem;
+				const firstAired = episode.first_aired;
 				const releaseDate = firstAired ? Utils.unix(firstAired) : undefined;
-				traktItem = new TraktItem({
-					id,
-					tmdbId,
-					type: 'show',
-					title,
-					year,
-					season,
-					episode,
-					episodeTitle,
+				traktItem = new TraktEpisodeItem({
+					id: episode.ids.trakt,
+					tmdbId: episode.ids.tmdb,
+					title: episode.title,
+					year: show.year,
+					season: episode.season,
+					number: episode.number,
 					releaseDate,
+					show: {
+						id: show.ids.trakt,
+						tmdbId: show.ids.tmdb,
+						title: show.title,
+						year: show.year,
+					},
 				});
 			} else {
-				const id = searchItem.movie.ids.trakt;
-				const tmdbId = searchItem.movie.ids.tmdb;
-				const title = searchItem.movie.title;
-				const year = searchItem.movie.year;
-				const released = searchItem.movie.released;
+				const { movie } = searchItem;
+				const released = movie.released;
 				const releaseDate = released ? Utils.unix(released) : undefined;
-				traktItem = new TraktItem({
-					id,
-					tmdbId,
-					type: 'movie',
-					title,
-					year,
+				traktItem = new TraktMovieItem({
+					id: movie.ids.trakt,
+					tmdbId: movie.ids.tmdb,
+					title: movie.title,
+					year: movie.year,
 					releaseDate,
 				});
 			}
@@ -146,7 +146,7 @@ class _TraktSearch extends TraktApi {
 			traktDatabaseId = traktItem.getDatabaseId();
 			caches.itemsToTraktItems.set(databaseId, traktDatabaseId);
 			caches.traktItems.set(traktDatabaseId, {
-				...TraktItem.save(traktItem),
+				...traktItem.save(),
 				syncId: undefined,
 				watchedAt: undefined,
 			});
@@ -187,7 +187,7 @@ class _TraktSearch extends TraktApi {
 		}
 	}
 
-	async findItem(item: Item, cancelKey = 'default'): Promise<TraktSearchItem> {
+	async findItem(item: ScrobbleItem, cancelKey = 'default'): Promise<TraktSearchItem> {
 		let searchItem: TraktSearchItem | undefined;
 		await this.activate();
 		const responseText = await this.requests.send({
@@ -220,7 +220,7 @@ class _TraktSearch extends TraktApi {
 				status: 404,
 				text: responseText,
 				extra: {
-					item: Item.save(item),
+					item: item.save(),
 				},
 			});
 		}
@@ -228,19 +228,20 @@ class _TraktSearch extends TraktApi {
 	}
 
 	async findShow(
-		itemOrUrl: Item | string,
+		itemOrUrl: EpisodeItem | string,
 		caches: CacheItems<['traktItems', 'urlsToTraktItems']>,
 		cancelKey = 'default'
 	): Promise<TraktSearchShowItem> {
-		const showUrl =
-			itemOrUrl instanceof Item
-				? `${itemOrUrl.type}?query=${encodeURIComponent(itemOrUrl.title)}`
-				: itemOrUrl;
+		const showUrl = isItem(itemOrUrl)
+			? `show?query=${encodeURIComponent(itemOrUrl.show.title)}`
+			: itemOrUrl;
 		let traktDatabaseId = caches.urlsToTraktItems.get(showUrl);
-		let cacheItem = traktDatabaseId ? caches.traktItems.get(traktDatabaseId) : null;
+		let cacheItem = traktDatabaseId
+			? (caches.traktItems.get(traktDatabaseId) as TraktShowItemValues | undefined)
+			: null;
 		if (!cacheItem) {
 			let show;
-			if (itemOrUrl instanceof Item) {
+			if (isItem(itemOrUrl)) {
 				show = ((await this.findItem(itemOrUrl, cancelKey)) as TraktSearchShowItem).show;
 			} else {
 				await this.activate();
@@ -275,11 +276,11 @@ class _TraktSearch extends TraktApi {
 	}
 
 	async findEpisode(
-		item: Item,
+		item: EpisodeItem,
 		caches: CacheItems<['traktItems', 'urlsToTraktItems']>,
 		cancelKey = 'default'
 	): Promise<TraktSearchEpisodeItem> {
-		let episodeItem: TraktEpisodeItem;
+		let episodeItem: TraktSearchEpisodeItemEpisode;
 		const showItem = await this.findShow(item, caches, cancelKey);
 		await this.activate();
 		const responseText = await this.requests.send({
@@ -287,28 +288,29 @@ class _TraktSearch extends TraktApi {
 			method: 'GET',
 			cancelKey,
 		});
-		if (item.episode) {
+		const response = JSON.parse(responseText) as TraktEpisodeItemEpisode | TraktSearchEpisodeItem[];
+		if (Array.isArray(response)) {
+			const episodeItems = response;
+			return this.findEpisodeByTitle(item, showItem, episodeItems);
+		} else {
 			episodeItem = {
-				episode: JSON.parse(responseText) as TraktEpisodeItemEpisode,
+				episode: response,
 			};
 			return Object.assign({}, episodeItem, showItem);
-		} else {
-			const episodeItems = JSON.parse(responseText) as TraktSearchEpisodeItem[];
-			return this.findEpisodeByTitle(item, showItem, episodeItems);
 		}
 	}
 
 	findEpisodeByTitle(
-		item: Item,
+		item: EpisodeItem,
 		showItem: TraktSearchShowItem,
 		episodeItems: TraktSearchEpisodeItem[]
 	): TraktSearchEpisodeItem {
 		const searchItem = episodeItems.find(
 			(x) =>
 				x.episode.title &&
-				item.episodeTitle &&
-				this.formatEpisodeTitle(x.episode.title) === this.formatEpisodeTitle(item.episodeTitle) &&
-				(this.formatEpisodeTitle(x.show.title).includes(this.formatEpisodeTitle(item.title)) ||
+				item.title &&
+				this.formatEpisodeTitle(x.episode.title) === this.formatEpisodeTitle(item.title) &&
+				(this.formatEpisodeTitle(x.show.title).includes(this.formatEpisodeTitle(item.show.title)) ||
 					this.formatEpisodeTitle(item.title).includes(this.formatEpisodeTitle(x.show.title)))
 		);
 		if (!searchItem) {
@@ -316,7 +318,7 @@ class _TraktSearch extends TraktApi {
 				status: 404,
 				text: 'Episode not found.',
 				extra: {
-					item: Item.save(item),
+					item: item.save(),
 					showItem,
 				},
 			});
@@ -324,15 +326,13 @@ class _TraktSearch extends TraktApi {
 		return searchItem;
 	}
 
-	getEpisodeUrl(item: Item, traktId: number): string {
+	getEpisodeUrl(item: EpisodeItem, traktId: number): string {
 		let url = '';
-		if (typeof item.season !== 'undefined' && typeof item.episode !== 'undefined') {
-			url = `${this.SHOWS_URL}/${traktId}/seasons/${item.season}/episodes/${item.episode}?extended=full`;
-		} else if (item.episodeTitle) {
-			url = `${this.SEARCH_URL}/episode?query=${encodeURIComponent(
-				item.episodeTitle
-			)}&extended=full`;
-		} else if (typeof item.season !== 'undefined') {
+		if (item.season && item.number) {
+			url = `${this.SHOWS_URL}/${traktId}/seasons/${item.season}/episodes/${item.number}?extended=full`;
+		} else if (item.title) {
+			url = `${this.SEARCH_URL}/episode?query=${encodeURIComponent(item.title)}&extended=full`;
+		} else if (item.season) {
 			url = `${this.SHOWS_URL}/${traktId}/seasons/${item.season}?extended=full`;
 		}
 		return url;

--- a/src/apis/TraktSync.ts
+++ b/src/apis/TraktSync.ts
@@ -3,7 +3,7 @@ import { Cache, CacheItem } from '@common/Cache';
 import { RequestPriority } from '@common/Requests';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 import { SyncStore } from '@stores/SyncStore';
 
 export interface TraktHistoryItem {
@@ -39,7 +39,7 @@ class _TraktSync extends TraktApi {
 	}
 
 	async loadHistory(
-		item: Item,
+		item: ScrobbleItem,
 		traktHistoryItemsCache: CacheItem<'traktHistoryItems'>,
 		forceRefresh = false,
 		cancelKey = 'default'
@@ -82,7 +82,7 @@ class _TraktSync extends TraktApi {
 		}
 	}
 
-	async removeHistory(item: Item): Promise<void> {
+	async removeHistory(item: ScrobbleItem): Promise<void> {
 		if (!item.trakt?.syncId) {
 			return;
 		}
@@ -98,12 +98,12 @@ class _TraktSync extends TraktApi {
 		item.trakt.watchedAt = undefined;
 	}
 
-	getUrl(item: Item): string {
+	getUrl(item: ScrobbleItem): string {
 		if (!item.trakt) {
 			return '';
 		}
 		let url = '';
-		if (item.trakt.type === 'show') {
+		if (item.trakt.type === 'episode') {
 			url = `${this.SYNC_URL}/episodes/${item.trakt.id}`;
 		} else {
 			url = `${this.SYNC_URL}/movies/${item.trakt.id}`;
@@ -111,12 +111,12 @@ class _TraktSync extends TraktApi {
 		return url;
 	}
 
-	async sync(store: SyncStore, items: Item[], cancelKey = 'sync') {
-		const newItems: Item[] = [];
+	async sync(store: SyncStore, items: ScrobbleItem[], cancelKey = 'sync') {
+		const newItems: ScrobbleItem[] = [];
 		try {
 			const data = {
 				episodes: items
-					.filter((item) => item.type === 'show')
+					.filter((item) => item.type === 'episode')
 					.map((item) => ({
 						ids: { trakt: item.trakt?.id },
 						watched_at: Utils.convertToISOString(item.getWatchedDate()),
@@ -144,7 +144,7 @@ class _TraktSync extends TraktApi {
 			for (const item of items) {
 				if (
 					item.trakt &&
-					((item.type === 'show' && !notFoundItems.episodes.includes(item.trakt.id)) ||
+					((item.type === 'episode' && !notFoundItems.episodes.includes(item.trakt.id)) ||
 						(item.type === 'movie' && !notFoundItems.movies.includes(item.trakt.id)))
 				) {
 					const newItem = item.clone();

--- a/src/common/AutoSync.ts
+++ b/src/common/AutoSync.ts
@@ -7,7 +7,7 @@ import { I18N } from '@common/I18N';
 import { RequestError } from '@common/RequestError';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 import { getServices, Service } from '@models/Service';
 import '@services-apis';
 import { getSyncStore } from '@stores/SyncStore';
@@ -91,7 +91,7 @@ class _AutoSync {
 			let wasCanceled = false;
 
 			const serviceValue = Shared.storage.options.services[service.id];
-			let items: Item[] = [];
+			let items: ScrobbleItem[] = [];
 
 			const api = getServiceApi(service.id);
 			const store = getSyncStore(service.id);
@@ -151,7 +151,7 @@ class _AutoSync {
 						[service.id]: partialServiceValue,
 					},
 				});
-				syncCache.items.unshift(...items.map((item) => Item.save(item)));
+				syncCache.items.unshift(...items.map((item) => item.save()));
 			}
 		}
 

--- a/src/common/Cache.ts
+++ b/src/common/Cache.ts
@@ -4,8 +4,8 @@ import { TraktSettingsResponse } from '@apis/TraktSettings';
 import { TraktHistoryItem } from '@apis/TraktSync';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { SavedItem } from '@models/Item';
-import { SavedTraktItem } from '@models/TraktItem';
+import { ScrobbleItemValues } from '@models/Item';
+import { TraktItemValues } from '@models/TraktItem';
 
 export type CacheItems<T extends (keyof CacheValues)[]> = {
 	[K in T[number]]: CacheItem<K>;
@@ -19,13 +19,13 @@ export interface CacheSubValues {
 	history: HistoryCache;
 	historyItemsToItems: string;
 	imageUrls: string | null;
-	items: SavedItem;
+	items: ScrobbleItemValues;
 	itemsToTraktItems: string;
 	servicesData: unknown;
 	suggestions: Suggestion[] | null;
 	tmdbApiConfigs: TmdbApiConfig | null;
 	traktHistoryItems: TraktHistoryItem[];
-	traktItems: SavedTraktItem;
+	traktItems: TraktItemValues;
 	traktSettings: TraktSettingsResponse;
 	urlsToTraktItems: string;
 }

--- a/src/common/Events.ts
+++ b/src/common/Events.ts
@@ -6,8 +6,8 @@ import {
 } from '@common/BrowserStorage';
 import { DispatchEventMessage, Messaging } from '@common/Messaging';
 import { Shared } from '@common/Shared';
-import { Item, SavedItem } from '@models/Item';
-import { SavedTraktItem } from '@models/TraktItem';
+import { ScrobbleItem, ScrobbleItemValues } from '@models/Item';
+import { TraktItemValues } from '@models/TraktItem';
 import { AlertColor } from '@mui/material';
 import { SyncStore } from '@stores/SyncStore';
 import { ReactNode } from 'react';
@@ -64,7 +64,7 @@ export interface LoginSuccessData {
 }
 
 export interface ScrobbleSuccessData {
-	item?: SavedTraktItem;
+	item?: TraktItemValues;
 	scrobbleType: number;
 }
 
@@ -94,22 +94,22 @@ export interface SnackbarShowData {
 }
 
 export interface MissingWatchedDateDialogShowData {
-	items: Item[];
+	items: ScrobbleItem[];
 }
 
 export interface MissingWatchedDateAddedData {
-	oldItems: Item[];
-	newItems: Item[];
+	oldItems: ScrobbleItem[];
+	newItems: ScrobbleItem[];
 }
 
 export interface CorrectionDialogShowData {
-	item?: Item;
+	item?: ScrobbleItem;
 	isScrobblingItem: boolean;
 }
 
 export interface ItemCorrectedData {
-	oldItem: SavedItem;
-	newItem: SavedItem;
+	oldItem: ScrobbleItemValues;
+	newItem: ScrobbleItemValues;
 }
 
 export interface HistorySyncSuccessData {
@@ -136,15 +136,11 @@ export interface ContentScriptConnectData {
 export interface SyncDialogShowData {
 	store: SyncStore;
 	serviceId: string | null;
-	items: Item[];
-}
-
-export interface ItemsUpdateData {
-	items: Item[];
+	items: ScrobbleItem[];
 }
 
 export interface ItemsLoadData {
-	items: Partial<Record<number, Item | null>>;
+	items: Partial<Record<number, ScrobbleItem | null>>;
 }
 
 export type EventDispatcherListeners = Record<

--- a/src/common/ScrobbleEvents.ts
+++ b/src/common/ScrobbleEvents.ts
@@ -15,7 +15,7 @@ export interface ScrobbleEventsOptions {
 
 const scrobbleEvents = new Map<string, ScrobbleEvents>();
 
-export const getScrobbleEvents = (id: string) => {
+export const getScrobbleEvents = (id: string): ScrobbleEvents => {
 	if (!scrobbleEvents.has(id)) {
 		const controller = getScrobbleController(id);
 		scrobbleEvents.set(id, new ScrobbleEvents(controller));
@@ -59,19 +59,19 @@ export class ScrobbleEvents {
 		return window.location.href;
 	}
 
-	init() {
+	init(): void {
 		this.checkListeners();
 		Shared.events.subscribe('STORAGE_OPTIONS_CHANGE', null, this.onStorageOptionsChange);
 	}
 
-	onStorageOptionsChange = (data: StorageOptionsChangeData) => {
+	onStorageOptionsChange = (data: StorageOptionsChangeData): void => {
 		const serviceOption = data.options?.services?.[this.api.id];
 		if (serviceOption && 'scrobble' in serviceOption) {
 			this.checkListeners();
 		}
 	};
 
-	checkListeners() {
+	checkListeners(): void {
 		const { scrobble } = Shared.storage.options.services[this.api.id];
 		if (scrobble && !this.hasAddedListeners) {
 			void this.checkForChanges();

--- a/src/components/CorrectionDialog.tsx
+++ b/src/components/CorrectionDialog.tsx
@@ -6,7 +6,7 @@ import { I18N } from '@common/I18N';
 import { Shared } from '@common/Shared';
 import { Center } from '@components/Center';
 import { CustomDialogRoot } from '@components/CustomDialogRoot';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 import {
 	Button,
 	CircularProgress,
@@ -27,7 +27,7 @@ import { FixedSizeList, ListChildComponentProps } from 'react-window';
 interface CorrectionDialogState {
 	isOpen: boolean;
 	isLoading: boolean;
-	item?: Item;
+	item?: ScrobbleItem;
 	isScrobblingItem: boolean;
 	url: string;
 }
@@ -124,7 +124,7 @@ export const CorrectionDialog = (): JSX.Element => {
 			}
 			if (!suggestion) {
 				suggestion = {
-					type: newItem.trakt.type === 'show' ? 'episode' : 'movie',
+					type: newItem.trakt.type,
 					id: newItem.trakt.id,
 					title: newItem.trakt.title,
 					count: 1,
@@ -142,8 +142,8 @@ export const CorrectionDialog = (): JSX.Element => {
 				dialog.isScrobblingItem ? 'SCROBBLING_ITEM_CORRECTED' : 'ITEM_CORRECTED',
 				null,
 				{
-					oldItem: Item.save(oldItem),
-					newItem: Item.save(newItem),
+					oldItem: oldItem.save(),
+					newItem: newItem.save(),
 				}
 			);
 		} catch (err) {
@@ -236,9 +236,9 @@ export const CorrectionDialog = (): JSX.Element => {
 									: 'correctionDialogContent',
 								dialog.item
 									? `${dialog.item.title} ${
-											dialog.item.type === 'show'
+											dialog.item.type === 'episode'
 												? `S${dialog.item.season?.toString() ?? '0'} E${
-														dialog.item.episode?.toString() ?? '0'
+														dialog.item.number?.toString() ?? '0'
 												  }`
 												: `(${dialog.item.year.toString()})`
 									  }`

--- a/src/components/MissingWatchedDateDialog.tsx
+++ b/src/components/MissingWatchedDateDialog.tsx
@@ -4,7 +4,7 @@ import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
 import { Center } from '@components/Center';
 import { CustomDialogRoot } from '@components/CustomDialogRoot';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 import { DateTimePicker, LocalizationProvider } from '@mui/lab';
 import DateAdapter from '@mui/lab/AdapterDateFns';
 import {
@@ -24,7 +24,7 @@ import { ChangeEvent, ReactNode, useEffect, useState } from 'react';
 interface MissingWatchedDateDialogState {
 	isOpen: boolean;
 	isLoading: boolean;
-	items: Item[];
+	items: ScrobbleItem[];
 	dateType: MissingWatchedDateType | null;
 	date: number | null;
 	dateError: ReactNode | null;
@@ -198,9 +198,9 @@ export const MissingWatchedDateDialog = (): JSX.Element => {
 								: I18N.translate(
 										'missingWatchedDateDialogContent',
 										`${dialog.items[0].title} ${
-											dialog.items[0].type === 'show'
+											dialog.items[0].type === 'episode'
 												? `S${dialog.items[0].season?.toString() ?? '0'} E${
-														dialog.items[0].episode?.toString() ?? '0'
+														dialog.items[0].number?.toString() ?? '0'
 												  }`
 												: `(${dialog.items[0].year.toString()})`
 										}`

--- a/src/components/SyncDialog.tsx
+++ b/src/components/SyncDialog.tsx
@@ -5,7 +5,7 @@ import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
 import { Center } from '@components/Center';
 import { CustomDialogRoot } from '@components/CustomDialogRoot';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 import { Button, CircularProgress, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 import { SyncStore } from '@stores/SyncStore';
 import { useEffect, useState } from 'react';
@@ -39,7 +39,7 @@ export const SyncDialog = (): JSX.Element => {
 			void startSync(data.store, data.serviceId, data.items);
 		};
 
-		const startSync = async (store: SyncStore, serviceId: string | null, items: Item[]) => {
+		const startSync = async (store: SyncStore, serviceId: string | null, items: ScrobbleItem[]) => {
 			if (!store || items.length === 0) {
 				closeDialog();
 				return;

--- a/src/contexts/HistoryContext.tsx
+++ b/src/contexts/HistoryContext.tsx
@@ -7,7 +7,7 @@ const history = createHashHistory();
 
 export const HistoryContext = createContext(history);
 
-export const useHistory = () => {
+export const useHistory = (): typeof history => {
 	const historyContext = useContext(HistoryContext);
 	if (typeof historyContext === 'undefined') {
 		throw new Error('useHistory() must be called from <HistoryProvider/>');

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -17,7 +17,7 @@ const getInitialValue = (): SessionContextValue => {
 
 export const SessionContext = createContext(getInitialValue());
 
-export const useSession = () => {
+export const useSession = (): SessionContextValue => {
 	const sessionContext = useContext(SessionContext);
 	if (typeof sessionContext === 'undefined') {
 		throw new Error('useSession() must be called from <SessionProvider/>');

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -12,7 +12,7 @@ export interface SyncContextValue {
 
 export const SyncContext = createContext<SyncContextValue>({} as SyncContextValue);
 
-export const useSync = () => {
+export const useSync = (): SyncContextValue => {
 	const syncContext = useContext(SyncContext);
 	if (typeof syncContext === 'undefined') {
 		throw new Error('useSync() must be called from <SyncProvider/>');

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -1,6 +1,17 @@
 import { Suggestion } from '@apis/CorrectionApi';
 import { Shared } from '@common/Shared';
-import { SavedTraktItem, TraktItem } from '@models/TraktItem';
+import {
+	TraktEpisodeItem,
+	TraktEpisodeItemParams,
+	TraktEpisodeItemValues,
+	TraktItem,
+	TraktMovieItem,
+	TraktMovieItemParams,
+	TraktMovieItemValues,
+	TraktShowItem,
+	TraktShowItemParams,
+	TraktShowItemValues,
+} from '@models/TraktItem';
 
 // We use this to correct known wrong titles.
 const correctTitles: Record<string, string> = {
@@ -16,9 +27,21 @@ const correctTitles: Record<string, string> = {
 	['Young and Hungry']: '"Young and Hungry"',
 };
 
-export interface IItem extends ItemBase {
+export type Item = ScrobbleItem | ShowItem;
+
+export type ScrobbleItem = EpisodeItem | MovieItem;
+
+export type ItemValues = ScrobbleItemValues | ShowItemValues;
+
+export type ScrobbleItemValues = EpisodeItemValues | MovieItemValues;
+
+export interface BaseItemValues {
+	serviceId: string;
+	id?: string | null;
+	title: string;
+	year?: number;
 	watchedAt?: number;
-	trakt?: TraktItem | null;
+	progress?: number;
 	isHidden?: boolean;
 	isSelected?: boolean;
 	index?: number;
@@ -27,94 +50,79 @@ export interface IItem extends ItemBase {
 	isLoading?: boolean;
 }
 
-export interface SavedItem extends ItemBase {
-	watchedAt?: number;
-	trakt?: Omit<SavedTraktItem, ''> | null;
-	suggestions?: Omit<Suggestion, ''>[] | null;
-	imageUrl?: string | null;
-	index?: number;
+export type EpisodeItemParams = Omit<EpisodeItemValues, 'type' | 'show' | 'trakt'> & {
+	show: Omit<ShowItemValues, 'type'>;
+	trakt?: TraktEpisodeItemParams | null;
+};
+
+export interface EpisodeItemValues extends BaseItemValues {
+	type: 'episode';
+	season: number;
+	number: number;
+	show: ShowItemValues;
+	trakt?: TraktEpisodeItemValues | null;
 }
 
-export interface ItemBase {
-	serviceId: string;
-	id?: string | null;
-	type: 'show' | 'movie';
-	title: string;
-	year?: number;
-	season?: number;
-	episode?: number;
-	episodeTitle?: string;
-	progress?: number;
+export type ShowItemParams = Omit<ShowItemValues, 'type' | 'trakt'> & {
+	trakt?: TraktShowItemParams | null;
+};
+
+export interface ShowItemValues extends BaseItemValues {
+	type: 'show';
+	trakt?: TraktShowItemValues | null;
 }
 
-//TODO this should be refactored or split into show and movie. Inheritance could be used to get the similarities.
-export class Item implements IItem {
+export type MovieItemParams = Omit<MovieItemValues, 'type' | 'trakt'> & {
+	trakt?: TraktMovieItemParams | null;
+};
+
+export interface MovieItemValues extends BaseItemValues {
+	type: 'movie';
+	trakt?: TraktMovieItemValues | null;
+}
+
+abstract class BaseItem implements BaseItemValues {
 	serviceId: string;
 	id: string;
-	type: 'show' | 'movie';
 	title: string;
 	year: number;
-	season?: number;
-	episode?: number;
-	episodeTitle?: string;
 	watchedAt?: number;
 	progress: number;
-	trakt?: TraktItem | null;
 	isHidden: boolean;
 	isSelected: boolean;
 	index: number;
 	suggestions?: Suggestion[] | null;
 	imageUrl?: string | null;
 	isLoading: boolean;
+	trakt?: TraktItem | null;
 
-	constructor(options: IItem) {
-		this.serviceId = options.serviceId;
-		this.type = options.type;
-		this.title = correctTitles[options.title] || options.title;
-		this.year = options.year ?? 0;
-		if (this.type === 'show') {
-			this.season = options.season;
-			this.episode = options.episode;
-			this.episodeTitle = options.episodeTitle;
-		}
-		this.watchedAt = options.watchedAt;
-		this.progress = options.progress ? Math.round(options.progress * 100) / 100 : 0.0;
-		this.trakt = options.trakt && new TraktItem(options.trakt); // Ensures immutability.
-		this.isHidden = options.isHidden ?? false;
-		this.isSelected = options.isSelected ?? false;
-		this.index = options.index ?? 0;
-		this.suggestions = options.suggestions;
-		this.imageUrl = options.imageUrl;
-		this.isLoading = options.isLoading ?? false;
-		this.id = options.id || this.generateId();
+	constructor(values: BaseItemValues) {
+		this.serviceId = values.serviceId;
+		this.title = correctTitles[values.title] || values.title;
+		this.year = values.year ?? 0;
+		this.watchedAt = values.watchedAt;
+		this.progress = values.progress ? Math.round(values.progress * 100) / 100 : 0.0;
+		this.isHidden = values.isHidden ?? false;
+		this.isSelected = values.isSelected ?? false;
+		this.index = values.index ?? 0;
+		this.suggestions = values.suggestions;
+		this.imageUrl = values.imageUrl;
+		this.isLoading = values.isLoading ?? false;
+		this.id = values.id || this.generateId();
 	}
 
-	static save(item: Item): SavedItem {
+	save(): BaseItemValues {
 		return {
-			serviceId: item.serviceId,
-			id: item.id,
-			type: item.type,
-			title: item.title,
-			year: item.year,
-			season: item.season,
-			episode: item.episode,
-			episodeTitle: item.episodeTitle,
-			watchedAt: item.watchedAt,
-			progress: item.progress,
-			trakt: item.trakt && TraktItem.save(item.trakt),
-			suggestions: item.suggestions,
-			imageUrl: item.imageUrl,
-			index: item.index,
+			serviceId: this.serviceId,
+			id: this.id,
+			title: this.title,
+			year: this.year,
+			watchedAt: this.watchedAt,
+			progress: this.progress,
+			index: this.index,
+			suggestions: this.suggestions,
+			imageUrl: this.imageUrl,
 		};
-	}
-
-	static load(savedItem: SavedItem): Item {
-		const options: IItem = {
-			...savedItem,
-			trakt: savedItem.trakt && TraktItem.load(savedItem.trakt),
-		};
-
-		return new Item(options);
 	}
 
 	/**
@@ -124,25 +132,14 @@ export class Item implements IItem {
 	 *   - Show: `dark-s1-e1-secrets`
 	 *   - Movie: `resident-evil-the-final-chapter`
 	 */
-	generateId() {
-		const titleId = this.title.toLowerCase().replace(/[^A-Za-z0-9]/g, '');
-		if (this.type === 'show') {
-			const episodeTitleId = this.episodeTitle?.toLowerCase().replace(/[^A-Za-z0-9]/g, '') ?? '';
-			return `${titleId}-s${this.season?.toString() ?? '0'}-e${
-				this.episode?.toString() ?? '0'
-			}-${episodeTitleId}`;
-		}
-		return titleId;
-	}
+	abstract generateId(): string;
 
-	getFullTitle() {
-		if (this.type === 'show') {
-			return `${this.title} S${this.season?.toString() ?? '0'} E${
-				this.episode?.toString() ?? '0'
-			} - ${this.episodeTitle ?? 'Untitled'}`;
-		}
-		return `${this.title} (${this.year})`;
-	}
+	abstract getFullTitle(): string;
+
+	/**
+	 * Clones the item for immutability.
+	 */
+	abstract clone(): Item;
 
 	doHide() {
 		return (
@@ -183,11 +180,133 @@ export class Item implements IItem {
 	getDatabaseId() {
 		return `${this.serviceId}_${this.id}`;
 	}
+}
 
-	/**
-	 * Clones the item for immutability.
-	 */
-	clone() {
-		return new Item(this);
+export class EpisodeItem extends BaseItem implements EpisodeItemValues {
+	type = 'episode' as const;
+	season: number;
+	number: number;
+	show: ShowItem;
+	trakt?: TraktEpisodeItem | null;
+
+	constructor(values: EpisodeItemParams) {
+		super(values);
+		this.season = values.season;
+		this.number = values.number;
+		this.show = new ShowItem(values.show);
+		this.trakt = values.trakt && new TraktEpisodeItem(values.trakt);
+	}
+
+	save(): EpisodeItemValues {
+		return {
+			...super.save(),
+			type: this.type,
+			season: this.season,
+			number: this.number,
+			show: this.show.save(),
+			trakt: this.trakt?.save(),
+		};
+	}
+
+	generateId(): string {
+		return `${this.show.title.toLowerCase().replace(/[^A-Za-z0-9]/g, '')}-s${
+			this.season?.toString() ?? '0'
+		}-e${this.number?.toString() ?? '0'}-${
+			this.title?.toLowerCase().replace(/[^A-Za-z0-9]/g, '') ?? ''
+		}`;
+	}
+
+	getFullTitle(): string {
+		return `${this.show.title} S${this.season?.toString() ?? '0'} E${
+			this.number?.toString() ?? '0'
+		} - ${this.title ?? 'Untitled'}`;
+	}
+
+	clone(): EpisodeItem {
+		return new EpisodeItem(this);
 	}
 }
+
+export class ShowItem extends BaseItem implements ShowItemValues {
+	type = 'show' as const;
+	trakt?: TraktShowItem | null;
+
+	constructor(values: ShowItemParams) {
+		super(values);
+		this.trakt = values.trakt && new TraktShowItem(values.trakt);
+	}
+
+	save(): ShowItemValues {
+		return {
+			...super.save(),
+			type: this.type,
+			trakt: this.trakt?.save(),
+		};
+	}
+
+	generateId(): string {
+		return this.title.toLowerCase().replace(/[^A-Za-z0-9]/g, '');
+	}
+
+	getFullTitle(): string {
+		return `${this.title} (${this.year})`;
+	}
+
+	clone(): ShowItem {
+		return new ShowItem(this);
+	}
+}
+
+export class MovieItem extends BaseItem implements MovieItemValues {
+	type = 'movie' as const;
+	trakt?: TraktMovieItem | null;
+
+	constructor(values: ShowItemParams) {
+		super(values);
+		this.trakt = values.trakt && new TraktMovieItem(values.trakt);
+	}
+
+	save(): MovieItemValues {
+		return {
+			...super.save(),
+			type: this.type,
+			trakt: this.trakt?.save(),
+		};
+	}
+
+	generateId(): string {
+		return this.title.toLowerCase().replace(/[^A-Za-z0-9]/g, '');
+	}
+
+	getFullTitle(): string {
+		return `${this.title} (${this.year})`;
+	}
+
+	clone(): MovieItem {
+		return new MovieItem(this);
+	}
+}
+
+export const createItem = (values: ItemValues): Item => {
+	switch (values.type) {
+		case 'show':
+			return new ShowItem(values);
+
+		default:
+			return createScrobbleItem(values);
+	}
+};
+
+export const createScrobbleItem = (values: ScrobbleItemValues): ScrobbleItem => {
+	switch (values.type) {
+		case 'episode':
+			return new EpisodeItem(values);
+
+		case 'movie':
+			return new MovieItem(values);
+	}
+};
+
+export const isItem = (item: unknown): item is Item => {
+	return item instanceof BaseItem;
+};

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -50,11 +50,6 @@ export interface BaseItemValues {
 	isLoading?: boolean;
 }
 
-export type EpisodeItemParams = Omit<EpisodeItemValues, 'type' | 'show' | 'trakt'> & {
-	show: Omit<ShowItemValues, 'type'>;
-	trakt?: TraktEpisodeItemParams | null;
-};
-
 export interface EpisodeItemValues extends BaseItemValues {
 	type: 'episode';
 	season: number;
@@ -63,8 +58,9 @@ export interface EpisodeItemValues extends BaseItemValues {
 	trakt?: TraktEpisodeItemValues | null;
 }
 
-export type ShowItemParams = Omit<ShowItemValues, 'type' | 'trakt'> & {
-	trakt?: TraktShowItemParams | null;
+export type EpisodeItemParams = Omit<EpisodeItemValues, 'type' | 'show' | 'trakt'> & {
+	show: Omit<ShowItemValues, 'type'>;
+	trakt?: TraktEpisodeItemParams | null;
 };
 
 export interface ShowItemValues extends BaseItemValues {
@@ -72,14 +68,18 @@ export interface ShowItemValues extends BaseItemValues {
 	trakt?: TraktShowItemValues | null;
 }
 
-export type MovieItemParams = Omit<MovieItemValues, 'type' | 'trakt'> & {
-	trakt?: TraktMovieItemParams | null;
+export type ShowItemParams = Omit<ShowItemValues, 'type' | 'trakt'> & {
+	trakt?: TraktShowItemParams | null;
 };
 
 export interface MovieItemValues extends BaseItemValues {
 	type: 'movie';
 	trakt?: TraktMovieItemValues | null;
 }
+
+export type MovieItemParams = Omit<MovieItemValues, 'type' | 'trakt'> & {
+	trakt?: TraktMovieItemParams | null;
+};
 
 abstract class BaseItem implements BaseItemValues {
 	serviceId: string;

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -11,11 +11,11 @@ export interface ServiceValues {
 
 const services = new Map<string, Service>();
 
-export const registerService = (id: string, service: Service) => {
+export const registerService = (id: string, service: Service): void => {
 	services.set(id, service);
 };
 
-export const getService = (id: string) => {
+export const getService = (id: string): Service => {
 	const service = services.get(id);
 	if (!service) {
 		throw new Error(`Service not registered for ${id}`);
@@ -23,7 +23,7 @@ export const getService = (id: string) => {
 	return service;
 };
 
-export const getServices = () => {
+export const getServices = (): Service[] => {
 	return Array.from(services.values());
 };
 
@@ -50,7 +50,7 @@ export class Service implements ServiceValues {
 		registerService(this.id, this);
 	}
 
-	get path() {
+	get path(): string {
 		return `/${this.id}`;
 	}
 }

--- a/src/models/TraktItem.ts
+++ b/src/models/TraktItem.ts
@@ -1,100 +1,202 @@
-export interface ITraktItem extends TraktItemBase {
-	releaseDate?: number;
-	watchedAt?: number | null;
-}
+export type TraktItem = TraktScrobbleItem | TraktShowItem;
 
-export interface TraktItemBase {
+export type TraktScrobbleItem = TraktEpisodeItem | TraktMovieItem;
+
+export type TraktItemValues = TraktScrobbleItemValues | TraktShowItemValues;
+
+export type TraktScrobbleItemValues = TraktEpisodeItemValues | TraktMovieItemValues;
+
+export interface TraktBaseItemValues {
 	id: number;
 	tmdbId: number;
-	type: 'show' | 'movie';
+	syncId?: number;
 	title: string;
 	year: number;
-	season?: number;
-	episode?: number;
-	episodeTitle?: string;
-	syncId?: number;
+	releaseDate?: number;
+	watchedAt?: number | null;
 	progress?: number;
 }
 
-export interface SavedTraktItem extends TraktItemBase {
-	releaseDate?: number;
-	watchedAt?: number | null;
+export type TraktEpisodeItemParams = Omit<TraktEpisodeItemValues, 'type' | 'show'> & {
+	show: Omit<TraktShowItemValues, 'type'>;
+};
+
+export interface TraktEpisodeItemValues extends TraktBaseItemValues {
+	type: 'episode';
+	season: number;
+	number: number;
+	show: TraktShowItemValues;
 }
 
-export class TraktItem implements ITraktItem {
+export type TraktShowItemParams = Omit<TraktShowItemValues, 'type'>;
+
+export interface TraktShowItemValues extends TraktBaseItemValues {
+	type: 'show';
+}
+
+export type TraktMovieItemParams = Omit<TraktMovieItemValues, 'type'>;
+
+export interface TraktMovieItemValues extends TraktBaseItemValues {
+	type: 'movie';
+}
+
+abstract class TraktBaseItem implements TraktBaseItemValues {
 	id: number;
 	tmdbId: number;
-	type: 'show' | 'movie';
+	syncId?: number;
 	title: string;
 	year: number;
-	season?: number;
-	episode?: number;
-	episodeTitle?: string;
 	releaseDate?: number;
-	syncId?: number;
 	watchedAt?: number | null;
 	progress: number;
 
-	constructor(options: ITraktItem) {
-		this.id = options.id;
-		this.tmdbId = options.tmdbId;
-		this.type = options.type;
-		this.title = options.title;
-		this.year = options.year;
-		if (this.type === 'show') {
-			this.season = options.season;
-			this.episode = options.episode;
-			this.episodeTitle = options.episodeTitle;
-		}
-		this.releaseDate = options.releaseDate;
-		this.syncId = options.syncId;
-		this.watchedAt = options.watchedAt;
-		this.progress = options.progress ? Math.round(options.progress * 100) / 100 : 0.0;
+	constructor(values: TraktBaseItemValues) {
+		this.id = values.id;
+		this.tmdbId = values.tmdbId;
+		this.syncId = values.syncId;
+		this.title = values.title;
+		this.year = values.year;
+		this.releaseDate = values.releaseDate;
+		this.watchedAt = values.watchedAt;
+		this.progress = values.progress ? Math.round(values.progress * 100) / 100 : 0.0;
 	}
 
-	static save(item: TraktItem): SavedTraktItem {
+	save(): TraktBaseItemValues {
 		return {
-			id: item.id,
-			tmdbId: item.tmdbId,
-			type: item.type,
-			title: item.title,
-			year: item.year,
-			season: item.season,
-			episode: item.episode,
-			episodeTitle: item.episodeTitle,
-			releaseDate: item.releaseDate,
-			syncId: item.syncId,
-			watchedAt: item.watchedAt,
-			progress: item.progress,
+			id: this.id,
+			tmdbId: this.tmdbId,
+			syncId: this.syncId,
+			title: this.title,
+			year: this.year,
+			releaseDate: this.releaseDate,
+			watchedAt: this.watchedAt,
+			progress: this.progress,
 		};
-	}
-
-	static load(savedItem: SavedTraktItem): TraktItem {
-		const options: ITraktItem = {
-			...savedItem,
-		};
-		return new TraktItem(options);
 	}
 
 	/**
 	 * Returns the ID used to uniquely identify the item in the database.
 	 */
-	getDatabaseId() {
-		return `${this.type === 'show' ? 'episode' : 'movie'}_${this.id.toString()}`;
-	}
+	abstract getDatabaseId(): string;
+
+	abstract getHistoryUrl(): string;
 
 	/**
 	 * Clones the item for immutability.
 	 */
-	clone() {
-		return new TraktItem(this);
+	abstract clone(): TraktItem;
+}
+
+export class TraktEpisodeItem extends TraktBaseItem implements TraktEpisodeItemValues {
+	type = 'episode' as const;
+	season: number;
+	number: number;
+	show: TraktShowItem;
+
+	constructor(values: TraktEpisodeItemParams) {
+		super(values);
+		this.season = values.season;
+		this.number = values.number;
+		this.show = new TraktShowItem(values.show);
 	}
 
-	getHistoryUrl() {
-		if (this.type === 'show') {
-			return `https://trakt.tv/users/me/history?episode=${this.id}`;
-		}
+	save(): TraktEpisodeItemValues {
+		return {
+			...super.save(),
+			type: this.type,
+			season: this.season,
+			number: this.number,
+			show: this.show.save(),
+		};
+	}
 
-		return `https://trakt.tv/users/me/history?movie=${this.id}`;
+	getDatabaseId(): string {
+		return `episode_${this.id.toString()}`;
+	}
+
+	getHistoryUrl(): string {
+		return `https://trakt.tv/users/me/history?episode=${this.id}`;
+	}
+
+	clone(): TraktEpisodeItem {
+		return new TraktEpisodeItem(this);
 	}
 }
+
+export class TraktShowItem extends TraktBaseItem implements TraktShowItemValues {
+	type = 'show' as const;
+
+	constructor(values: TraktShowItemParams) {
+		super(values);
+	}
+
+	save(): TraktShowItemValues {
+		return {
+			...super.save(),
+			type: this.type,
+		};
+	}
+
+	getDatabaseId(): string {
+		return `show_${this.id.toString()}`;
+	}
+
+	getHistoryUrl(): string {
+		return `https://trakt.tv/users/me/history/episodes?show=${this.id}`;
+	}
+
+	clone(): TraktShowItem {
+		return new TraktShowItem(this);
+	}
+}
+
+export class TraktMovieItem extends TraktBaseItem implements TraktMovieItemValues {
+	type = 'movie' as const;
+
+	constructor(values: TraktMovieItemParams) {
+		super(values);
+	}
+
+	save(): TraktMovieItemValues {
+		return {
+			...super.save(),
+			type: this.type,
+		};
+	}
+
+	getDatabaseId(): string {
+		return `movie_${this.id.toString()}`;
+	}
+
+	getHistoryUrl(): string {
+		return `https://trakt.tv/users/me/history?movie=${this.id}`;
+	}
+
+	clone(): TraktMovieItem {
+		return new TraktMovieItem(this);
+	}
+}
+
+export const createTraktItem = (values: TraktItemValues): TraktItem => {
+	switch (values.type) {
+		case 'show':
+			return new TraktShowItem(values);
+
+		default:
+			return createTraktScrobbleItem(values);
+	}
+};
+
+export const createTraktScrobbleItem = (values: TraktScrobbleItemValues): TraktScrobbleItem => {
+	switch (values.type) {
+		case 'episode':
+			return new TraktEpisodeItem(values);
+
+		case 'movie':
+			return new TraktMovieItem(values);
+	}
+};
+
+export const isTraktItem = (item: unknown): item is TraktItem => {
+	return item instanceof TraktBaseItem;
+};

--- a/src/models/TraktItem.ts
+++ b/src/models/TraktItem.ts
@@ -17,10 +17,6 @@ export interface TraktBaseItemValues {
 	progress?: number;
 }
 
-export type TraktEpisodeItemParams = Omit<TraktEpisodeItemValues, 'type' | 'show'> & {
-	show: Omit<TraktShowItemValues, 'type'>;
-};
-
 export interface TraktEpisodeItemValues extends TraktBaseItemValues {
 	type: 'episode';
 	season: number;
@@ -28,17 +24,21 @@ export interface TraktEpisodeItemValues extends TraktBaseItemValues {
 	show: TraktShowItemValues;
 }
 
-export type TraktShowItemParams = Omit<TraktShowItemValues, 'type'>;
+export type TraktEpisodeItemParams = Omit<TraktEpisodeItemValues, 'type' | 'show'> & {
+	show: Omit<TraktShowItemValues, 'type'>;
+};
 
 export interface TraktShowItemValues extends TraktBaseItemValues {
 	type: 'show';
 }
 
-export type TraktMovieItemParams = Omit<TraktMovieItemValues, 'type'>;
+export type TraktShowItemParams = Omit<TraktShowItemValues, 'type'>;
 
 export interface TraktMovieItemValues extends TraktBaseItemValues {
 	type: 'movie';
 }
+
+export type TraktMovieItemParams = Omit<TraktMovieItemValues, 'type'>;
 
 abstract class TraktBaseItem implements TraktBaseItemValues {
 	id: number;

--- a/src/modules/content/service/service.ts
+++ b/src/modules/content/service/service.ts
@@ -8,7 +8,7 @@ import { getScrobbleController } from '@common/ScrobbleController';
 import { getScrobbleEvents } from '@common/ScrobbleEvents';
 import { Shared } from '@common/Shared';
 
-export const init = async (serviceId: string) => {
+export const init = async (serviceId: string): Promise<void> => {
 	Shared.pageType = 'content';
 	await BrowserStorage.init();
 	Errors.init();

--- a/src/modules/history/components/HistoryContainer.tsx
+++ b/src/modules/history/components/HistoryContainer.tsx
@@ -23,6 +23,7 @@ export const HistoryContainer = ({
 							padding: 0,
 					  }
 					: {}),
+				...sx,
 			}}
 		>
 			{children}

--- a/src/modules/history/components/HistoryListItem.tsx
+++ b/src/modules/history/components/HistoryListItem.tsx
@@ -4,7 +4,7 @@ import { Shared } from '@common/Shared';
 import { HistoryListItemCard } from '@components/HistoryListItemCard';
 import { HistoryListItemMessage } from '@components/HistoryListItemMessage';
 import { useSync } from '@contexts/SyncContext';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 import { getService } from '@models/Service';
 import { Sync as SyncIcon } from '@mui/icons-material';
 import { Box, Button, Checkbox, Tooltip, Typography } from '@mui/material';
@@ -28,7 +28,9 @@ const _HistoryListItem = ({
 	if (!serviceId) {
 		index -= 1;
 	}
-	const [item, setItem] = useState<Item | null | undefined>(store.data.items[index] ?? undefined);
+	const [item, setItem] = useState<ScrobbleItem | null | undefined>(
+		store.data.items[index] ?? undefined
+	);
 
 	const onCheckboxChange = async (event: ChangeEvent<HTMLInputElement>) => {
 		if (!item) {

--- a/src/modules/history/components/HistoryListItemCard.tsx
+++ b/src/modules/history/components/HistoryListItemCard.tsx
@@ -5,8 +5,8 @@ import { Utils } from '@common/Utils';
 import { Center } from '@components/Center';
 import { HistoryListItemDivider } from '@components/HistoryListItemDivider';
 import { TmdbImage } from '@components/TmdbImage';
-import { Item } from '@models/Item';
-import { TraktItem } from '@models/TraktItem';
+import { isItem, ScrobbleItem } from '@models/Item';
+import { isTraktItem, TraktItem } from '@models/TraktItem';
 import {
 	Button,
 	Card,
@@ -20,7 +20,7 @@ import {
 
 interface HistoryListItemCardProps {
 	isLoading: boolean;
-	item?: Item | TraktItem | null;
+	item?: ScrobbleItem | TraktItem | null;
 	name: string;
 	suggestions?: Suggestion[] | null;
 	imageUrl?: string | null;
@@ -37,11 +37,11 @@ export const HistoryListItemCard = ({
 	openMissingWatchedDateDialog,
 	openCorrectionDialog,
 }: HistoryListItemCardProps): JSX.Element => {
-	const watchedAt = item instanceof Item ? item.getWatchedDate() : item?.watchedAt;
+	const watchedAt = isItem(item) ? item.getWatchedDate() : item?.watchedAt;
 	let watchedAtComponent;
 	if (item) {
 		if (watchedAt) {
-			if (item instanceof Item) {
+			if (isItem(item)) {
 				watchedAtComponent = (
 					<Typography variant="overline">
 						{`${I18N.translate('watched')} ${Utils.timestamp(watchedAt)}`}
@@ -65,7 +65,7 @@ export const HistoryListItemCard = ({
 					</Typography>
 				);
 			}
-		} else if (item instanceof TraktItem && typeof watchedAt === 'undefined') {
+		} else if (isTraktItem(item) && typeof watchedAt === 'undefined') {
 			watchedAtComponent = (
 				<Typography variant="overline">{I18N.translate('loadingHistory')}...</Typography>
 			);
@@ -93,7 +93,7 @@ export const HistoryListItemCard = ({
 		);
 	}
 
-	const hasImage = item instanceof TraktItem || item === null;
+	const hasImage = isTraktItem(item) || item === null;
 	return (
 		<Card
 			variant="outlined"
@@ -123,13 +123,13 @@ export const HistoryListItemCard = ({
 						<>
 							{item === null ? (
 								<Typography variant="h6">{I18N.translate('notFound')}</Typography>
-							) : item.type === 'show' ? (
+							) : item.type === 'episode' ? (
 								<>
-									{item.season && item.episode && (
-										<Typography variant="overline">{`S${item.season} E${item.episode}`}</Typography>
+									{item.season && item.number && (
+										<Typography variant="overline">{`S${item.season} E${item.number}`}</Typography>
 									)}
-									<Typography variant="h6">{item.episodeTitle}</Typography>
-									<Typography variant="subtitle2">{item.title}</Typography>
+									<Typography variant="h6">{item.title}</Typography>
+									<Typography variant="subtitle2">{item.show.title}</Typography>
 									<HistoryListItemDivider useDarkMode={hasImage} />
 									{watchedAtComponent}
 								</>

--- a/src/modules/history/components/HistoryListItemCard.tsx
+++ b/src/modules/history/components/HistoryListItemCard.tsx
@@ -125,7 +125,7 @@ export const HistoryListItemCard = ({
 								<Typography variant="h6">{I18N.translate('notFound')}</Typography>
 							) : item.type === 'episode' ? (
 								<>
-									{item.season && item.number && (
+									{item.season > 0 && item.number > 0 && (
 										<Typography variant="overline">{`S${item.season} E${item.number}`}</Typography>
 									)}
 									<Typography variant="h6">{item.title}</Typography>

--- a/src/modules/history/pages/AutoSyncPage.tsx
+++ b/src/modules/history/pages/AutoSyncPage.tsx
@@ -1,6 +1,6 @@
 import { Shared } from '@common/Shared';
 import { useSync } from '@contexts/SyncContext';
-import { Item } from '@models/Item';
+import { createScrobbleItem } from '@models/Item';
 import { SyncPage } from '@pages/SyncPage';
 import { useEffect, useState } from 'react';
 
@@ -13,7 +13,7 @@ export const AutoSyncPage = (): JSX.Element => {
 		const loadCache = async () => {
 			const { syncCache } = await Shared.storage.get('syncCache');
 			if (syncCache && syncCache.items.length > 0) {
-				const items = syncCache.items.map((savedItem) => Item.load(savedItem));
+				const items = syncCache.items.map((savedItem) => createScrobbleItem(savedItem));
 				await store.setData({ items, hasReachedEnd: true });
 				setLoading(false);
 			}

--- a/src/modules/popup/components/PopupWatching.tsx
+++ b/src/modules/popup/components/PopupWatching.tsx
@@ -5,12 +5,12 @@ import { CustomSnackbar } from '@components/CustomSnackbar';
 import { PopupInfo } from '@components/PopupInfo';
 import { PopupOverlay } from '@components/PopupOverlay';
 import { TmdbImage } from '@components/TmdbImage';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 import { Pause as PauseIcon } from '@mui/icons-material';
 import { Box, Button, LinearProgress, Tooltip, Typography } from '@mui/material';
 
 export interface PopupWatchingProps {
-	item: Item;
+	item: ScrobbleItem;
 	isPaused: boolean;
 }
 
@@ -38,11 +38,11 @@ export const PopupWatching = ({ item, isPaused }: PopupWatchingProps): JSX.Eleme
 				>
 					<PopupInfo>
 						<Typography variant="overline">{I18N.translate('nowScrobbling')}</Typography>
-						{item.trakt?.type === 'show' ? (
+						{item.trakt?.type === 'episode' ? (
 							<>
-								<Typography variant="h6">{item.trakt.episodeTitle}</Typography>
+								<Typography variant="h6">{item.trakt.title}</Typography>
 								<Typography variant="subtitle2">{I18N.translate('from')}</Typography>
-								<Typography variant="subtitle1">{item.trakt.title}</Typography>
+								<Typography variant="subtitle1">{item.trakt.show.title}</Typography>
 							</>
 						) : (
 							<Typography variant="h6">{item.trakt?.title}</Typography>

--- a/src/modules/popup/pages/PopupHomePage.tsx
+++ b/src/modules/popup/pages/PopupHomePage.tsx
@@ -5,13 +5,13 @@ import { Shared } from '@common/Shared';
 import { Center } from '@components/Center';
 import { PopupNotWatching } from '@components/PopupNotWatching';
 import { PopupWatching } from '@components/PopupWatching';
-import { Item } from '@models/Item';
+import { createScrobbleItem, ScrobbleItem } from '@models/Item';
 import { CircularProgress } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 interface IPopupHomeContent {
 	isLoading: boolean;
-	scrobblingItem: Item | null;
+	scrobblingItem: ScrobbleItem | null;
 	isPaused: boolean;
 }
 
@@ -29,7 +29,7 @@ export const HomePage = (): JSX.Element => {
 			const { scrobblingDetails } = await Shared.storage.get('scrobblingDetails');
 			setContent({
 				isLoading: false,
-				scrobblingItem: scrobblingDetails?.item ? Item.load(scrobblingDetails.item) : null,
+				scrobblingItem: scrobblingDetails?.item ? createScrobbleItem(scrobblingDetails.item) : null,
 				isPaused: scrobblingDetails?.isPaused ?? false,
 			});
 		};
@@ -56,7 +56,7 @@ export const HomePage = (): JSX.Element => {
 			setContent((prevContent) => ({
 				...prevContent,
 				scrobblingItem: data.item
-					? Item.load({
+					? createScrobbleItem({
 							...data.item,
 							suggestions: prevContent.scrobblingItem?.suggestions,
 							imageUrl: prevContent.scrobblingItem?.imageUrl,
@@ -85,7 +85,7 @@ export const HomePage = (): JSX.Element => {
 			setContent((prevContent) => ({
 				...prevContent,
 				scrobblingItem: data.item
-					? Item.load({
+					? createScrobbleItem({
 							...data.item,
 							suggestions: prevContent.scrobblingItem?.suggestions,
 							imageUrl: prevContent.scrobblingItem?.imageUrl,

--- a/src/services/goplay-be/GoplayBeParser.ts
+++ b/src/services/goplay-be/GoplayBeParser.ts
@@ -1,6 +1,6 @@
 import { GoplayBeApi } from '@/goplay-be/GoplayBeApi';
 import { ScrobbleParser } from '@common/ScrobbleParser';
-import { Item } from '@models/Item';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _GoplayBeParser extends ScrobbleParser {
 	constructor() {
@@ -12,6 +12,11 @@ class _GoplayBeParser extends ScrobbleParser {
 	parseItemFromDom() {
 		const serviceId = this.api.id;
 		const titleElement = document.querySelector('title');
+
+		if (!titleElement) {
+			return null;
+		}
+
 		const id = this.parseItemIdFromUrl();
 		let showTitle: string | null = null;
 		let seasonId: string | null = null;
@@ -27,23 +32,28 @@ class _GoplayBeParser extends ScrobbleParser {
 		}
 
 		const title = showTitle ?? titleElement?.textContent ?? '';
-		const episodeTitle = '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const type = seasonId ? 'show' : 'movie';
 
-		if (!titleElement) {
-			return null;
+		if (seasonId) {
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: '',
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
 		}
 
-		return new Item({
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/hbo-go/HboGoApi.ts
+++ b/src/services/hbo-go/HboGoApi.ts
@@ -1,6 +1,5 @@
-import { ServiceApi } from '@apis/ServiceApi';
-import { Item } from '@models/Item';
 import { HboGoService } from '@/hbo-go/HboGoService';
+import { ServiceApi } from '@apis/ServiceApi';
 
 class _HboGoApi extends ServiceApi {
 	constructor() {

--- a/src/services/hbo-go/HboGoParser.ts
+++ b/src/services/hbo-go/HboGoParser.ts
@@ -1,6 +1,6 @@
-import { ScrobbleParser } from '@common/ScrobbleParser';
 import { HboGoApi } from '@/hbo-go/HboGoApi';
-import { Item } from '@models/Item';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _HboGoParser extends ScrobbleParser {
 	constructor() {
@@ -16,6 +16,10 @@ class _HboGoParser extends ScrobbleParser {
 		let seasonId: string | null = null;
 		let episodeId: string | null = null;
 
+		if (!titleElement) {
+			return null;
+		}
+
 		const matches = /.+ (?<seasonId>\d+) .+ (?<episodeId>\d+)/.exec(
 			subTitleElement?.textContent ?? ''
 		);
@@ -25,24 +29,26 @@ class _HboGoParser extends ScrobbleParser {
 		}
 
 		const title = titleElement?.textContent ?? '';
-		const episodeTitle = '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const id = (titleElement?.textContent ?? '') + '-' + String(season) + '-' + String(episode);
-		const type = seasonId ? 'show' : 'movie';
 
-		if (!titleElement) {
-			return null;
+		if (seasonId) {
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				title: '',
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
 		}
 
-		return new Item({
+		return new MovieItem({
 			serviceId,
-			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/kijk-nl/KijkNlApi.ts
+++ b/src/services/kijk-nl/KijkNlApi.ts
@@ -1,6 +1,5 @@
-import { ServiceApi } from '@apis/ServiceApi';
-import { Item } from '@models/Item';
 import { KijkNlService } from '@/kijk-nl/KijkNlService';
+import { ServiceApi } from '@apis/ServiceApi';
 
 class _KijkNlApi extends ServiceApi {
 	constructor() {

--- a/src/services/kijk-nl/KijkNlParser.ts
+++ b/src/services/kijk-nl/KijkNlParser.ts
@@ -1,6 +1,6 @@
-import { ScrobbleParser } from '@common/ScrobbleParser';
 import { KijkNlApi } from '@/kijk-nl/KijkNlApi';
-import { Item } from '@models/Item';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _KijkNlParser extends ScrobbleParser {
 	constructor() {
@@ -17,6 +17,10 @@ class _KijkNlParser extends ScrobbleParser {
 		let seasonId: string | null = null;
 		let episodeId: string | null = null;
 
+		if (!titleElement) {
+			return null;
+		}
+
 		// Shows get a title like this (dutch example): "Steenrijk, straatarm - seizoen 2 aflevering 1"
 		const matches = /(?<showTitle>.+) - seizoen (?<seasonId>\d+) aflevering (?<episodeId>\d+)/.exec(
 			titleElement?.textContent ?? ''
@@ -27,23 +31,29 @@ class _KijkNlParser extends ScrobbleParser {
 		}
 
 		const title = showTitle?.split(' - ')[0] ?? titleElement?.textContent ?? '';
-		const episodeTitle = showTitle?.split(' - ')[1] ?? '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const type = seasonId ? 'show' : 'movie';
 
-		if (!titleElement) {
-			return null;
+		if (seasonId) {
+			const episodeTitle = showTitle?.split(' - ')[1] ?? '';
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: episodeTitle,
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
 		}
 
-		return new Item({
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/player-pl/PlayerPlApi.ts
+++ b/src/services/player-pl/PlayerPlApi.ts
@@ -1,6 +1,5 @@
-import { ServiceApi } from '@apis/ServiceApi';
-import { Item } from '@models/Item';
 import { PlayerPlService } from '@/player-pl/PlayerPlService';
+import { ServiceApi } from '@apis/ServiceApi';
 
 class _PlayerPlApi extends ServiceApi {
 	constructor() {

--- a/src/services/player-pl/PlayerPlParser.ts
+++ b/src/services/player-pl/PlayerPlParser.ts
@@ -1,6 +1,6 @@
-import { ScrobbleParser } from '@common/ScrobbleParser';
 import { PlayerPlApi } from '@/player-pl/PlayerPlApi';
-import { Item } from '@models/Item';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _PlayerPlParser extends ScrobbleParser {
 	constructor() {
@@ -20,6 +20,11 @@ class _PlayerPlParser extends ScrobbleParser {
 	parseItemFromDom() {
 		const serviceId = this.api.id;
 		const titleElement = document.querySelector('.seo-visible h1');
+
+		if (!titleElement) {
+			return null;
+		}
+
 		const episodeTitleElement = document.querySelector(
 			'' + 'span[data-test-id="nuvi-asset-info-box-title"]'
 		);
@@ -40,23 +45,28 @@ class _PlayerPlParser extends ScrobbleParser {
 		}
 
 		const title = titleElement?.textContent ?? '';
-		const episodeTitle = episodeTitleElement?.textContent ?? '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const type = season > 0 ? 'show' : 'movie';
 
-		if (!titleElement) {
-			return null;
+		if (seasonId) {
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: episodeTitleElement?.textContent ?? '',
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
 		}
 
-		return new Item({
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/polsatboxgo-pl/PolsatboxgoPlApi.ts
+++ b/src/services/polsatboxgo-pl/PolsatboxgoPlApi.ts
@@ -1,6 +1,5 @@
-import { ServiceApi } from '@apis/ServiceApi';
-import { Item } from '@models/Item';
 import { PolsatboxgoPlService } from '@/polsatboxgo-pl/PolsatboxgoPlService';
+import { ServiceApi } from '@apis/ServiceApi';
 
 class _PolsatboxgoPlApi extends ServiceApi {
 	constructor() {

--- a/src/services/polsatboxgo-pl/PolsatboxgoPlParser.ts
+++ b/src/services/polsatboxgo-pl/PolsatboxgoPlParser.ts
@@ -1,6 +1,6 @@
-import { ScrobbleParser } from '@common/ScrobbleParser';
 import { PolsatboxgoPlApi } from '@/polsatboxgo-pl/PolsatboxgoPlApi';
-import { Item } from '@models/Item';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _PolsatboxgoPlParser extends ScrobbleParser {
 	constructor() {
@@ -34,23 +34,32 @@ class _PolsatboxgoPlParser extends ScrobbleParser {
 		}
 
 		const title = showTitle?.split('/')[0];
-		const episodeTitle = epiTitle ?? '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const type = seasonId ? 'show' : 'movie';
 
 		if (!title) {
 			return null;
 		}
 
-		return new Item({
+		if (seasonId) {
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: epiTitle ?? '',
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
+		}
+
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/streamz-be/StreamzBeParser.ts
+++ b/src/services/streamz-be/StreamzBeParser.ts
@@ -1,6 +1,6 @@
 import { StreamzBeApi } from '@/streamz-be/StreamzBeApi';
 import { ScrobbleParser } from '@common/ScrobbleParser';
-import { Item } from '@models/Item';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _StreamzBeParser extends ScrobbleParser {
 	constructor() {
@@ -18,6 +18,10 @@ class _StreamzBeParser extends ScrobbleParser {
 		let episodeId: string | null = null;
 		let subTitle: string | undefined = undefined;
 
+		if (!titleElement) {
+			return null;
+		}
+
 		// Shows get a title like this (dutch example): "Raised by Wolves S1 A1 Aflevering 1"
 		const matches = /(?<showTitle>.+) S(?<seasonId>\d+) A(?<episodeId>\d+) (?<subTitle>.+)/.exec(
 			titleElement?.textContent ?? ''
@@ -28,23 +32,28 @@ class _StreamzBeParser extends ScrobbleParser {
 		}
 
 		const title = showTitle ?? titleElement?.textContent ?? '';
-		const episodeTitle = subTitle ?? '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const type = seasonId ? 'show' : 'movie';
 
-		if (!titleElement) {
-			return null;
+		if (seasonId) {
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: subTitle ?? '',
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
 		}
 
-		return new Item({
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/viaplay/ViaplayApi.ts
+++ b/src/services/viaplay/ViaplayApi.ts
@@ -3,7 +3,7 @@ import { ServiceApi } from '@apis/ServiceApi';
 import { Requests } from '@common/Requests';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { Item } from '@models/Item';
+import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
 
 export interface ViaplayAuthResponse {
 	success: boolean;
@@ -163,7 +163,7 @@ class _ViaplayApi extends ServiceApi {
 		return responseItems;
 	}
 
-	isNewHistoryItem(historyItem: ViaplayProduct, lastSync: number, lastSyncId: string) {
+	isNewHistoryItem(historyItem: ViaplayProduct, lastSync: number) {
 		return (
 			!!historyItem.user.progress?.updated &&
 			Utils.unix(historyItem.user.progress.updated) > lastSync
@@ -179,8 +179,8 @@ class _ViaplayApi extends ServiceApi {
 		return items;
 	}
 
-	parseViaplayProduct(product: ViaplayProduct): Item {
-		let item: Item;
+	parseViaplayProduct(product: ViaplayProduct): ScrobbleItem {
+		let item: ScrobbleItem;
 		const serviceId = this.id;
 		const year = product.content.production.year;
 		const progressInfo = product.user.progress;
@@ -189,28 +189,30 @@ class _ViaplayApi extends ServiceApi {
 		const id = product.system.guid;
 		if (product.type === 'episode') {
 			const content = product.content;
-			const title = content.originalTitle ?? content.series.title;
+			const showTitle = content.originalTitle ?? content.series.title;
 			const season = content.series.season.seasonNumber;
-			const episode = content.series.episodeNumber;
-			const episodeTitle = content.title !== title ? content.title : content.series.episodeTitle;
-			item = new Item({
+			const number = content.series.episodeNumber;
+			const title = content.title !== showTitle ? content.title : content.series.episodeTitle;
+			item = new EpisodeItem({
 				serviceId,
 				id,
-				type: 'show',
 				title,
 				year,
 				season,
-				episode,
-				episodeTitle,
+				number,
 				progress,
 				watchedAt,
+				show: {
+					serviceId,
+					title: showTitle,
+					year,
+				},
 			});
 		} else {
 			const title = product.content.title;
-			item = new Item({
+			item = new MovieItem({
 				serviceId,
 				id,
-				type: 'movie',
 				title,
 				year,
 				progress,
@@ -220,8 +222,8 @@ class _ViaplayApi extends ServiceApi {
 		return item;
 	}
 
-	async getItem(id: string): Promise<Item | null> {
-		let item: Item | null = null;
+	async getItem(id: string): Promise<ScrobbleItem | null> {
+		let item: ScrobbleItem | null = null;
 		if (!this.isActivated) {
 			await this.activate();
 		}

--- a/src/services/vrtnu-be/VrtnuBeParser.ts
+++ b/src/services/vrtnu-be/VrtnuBeParser.ts
@@ -1,6 +1,6 @@
 import { VrtnuBeApi } from '@/vrtnu-be/VrtnuBeApi';
 import { ScrobbleParser } from '@common/ScrobbleParser';
-import { Item } from '@models/Item';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _VrtnuBeParser extends ScrobbleParser {
 	constructor() {
@@ -29,26 +29,37 @@ class _VrtnuBeParser extends ScrobbleParser {
 			({ showTitle, seasonOrYear, id, seasonAndEpisode, seasonStr, episodeStr } = matches.groups);
 		}
 
-		const title = showTitle?.split('-').join(' ') ?? '';
-		const episodeTitle = '';
-		const season = seasonAndEpisode ? parseInt(seasonStr ?? '') : undefined;
-		const episode = seasonAndEpisode ? parseInt(episodeStr ?? '') : undefined;
-		const type = seasonAndEpisode ? 'show' : 'movie';
-		const year = !seasonAndEpisode ? parseInt(seasonOrYear ?? '') : 0;
-
 		if (!id) {
 			return null;
 		}
 
-		return new Item({
+		const title = showTitle?.split('-').join(' ') ?? '';
+
+		if (seasonAndEpisode) {
+			const season = parseInt(seasonStr ?? '') || 0;
+			const number = parseInt(episodeStr ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: '',
+				season,
+				number,
+				show: {
+					serviceId,
+					id,
+					title,
+				},
+			});
+		}
+
+		const year = parseInt(seasonOrYear ?? '') || 0;
+
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
 			year,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/vtmgo-be/VtmgoBeParser.ts
+++ b/src/services/vtmgo-be/VtmgoBeParser.ts
@@ -1,6 +1,6 @@
 import { VtmgoBeApi } from '@/vtmgo-be/VtmgoBeApi';
 import { ScrobbleParser } from '@common/ScrobbleParser';
-import { Item } from '@models/Item';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _VtmgoBeParser extends ScrobbleParser {
 	constructor() {
@@ -18,6 +18,10 @@ class _VtmgoBeParser extends ScrobbleParser {
 		let episodeId: string | null = null;
 		let subTitle: string | undefined = undefined;
 
+		if (!titleElement) {
+			return null;
+		}
+
 		// Shows get a title like this (dutch example): "Huis Gesmaakt met Gert Voorjans S1 A1 Aflevering 1"
 		const matches = /(?<showTitle>.+) S(?<seasonId>\d+) A(?<episodeId>\d+) (?<subTitle>.+)/.exec(
 			titleElement?.textContent ?? ''
@@ -28,23 +32,28 @@ class _VtmgoBeParser extends ScrobbleParser {
 		}
 
 		const title = showTitle ?? titleElement?.textContent ?? '';
-		const episodeTitle = subTitle ?? '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const type = seasonId ? 'show' : 'movie';
 
-		if (!titleElement) {
-			return null;
+		if (seasonId) {
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: subTitle ?? '',
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
 		}
 
-		return new Item({
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/services/wakanim-tv/WakanimTvParser.ts
+++ b/src/services/wakanim-tv/WakanimTvParser.ts
@@ -1,6 +1,6 @@
-import { ScrobbleParser } from '@common/ScrobbleParser';
 import { WakanimTvApi } from '@/wakanim-tv/WakanimTvApi';
-import { Item } from '@models/Item';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _WakanimTvParser extends ScrobbleParser {
 	constructor() {
@@ -23,6 +23,10 @@ class _WakanimTvParser extends ScrobbleParser {
 		let seasonId: string | null = null;
 		let episodeId: string | null = null;
 
+		if (!titleElement) {
+			return null;
+		}
+
 		// "Drowning Sorrows in Raging Fire Saison 1 Episode 12 VOSTFR - Regardez officiellement sur Wakanim.TV"
 		// "Deep Insanity THE LOST CHILD Saison 1 - VOSTFR Episode 12 VOSTFR - Regardez officiellement sur Wakanim.TV"
 		// "Ranking of Kings Staffel 1 - Cour 2 (OmU) Folge 12 (OmU.) - Schaue legal auf Wakanim.TV"
@@ -37,23 +41,28 @@ class _WakanimTvParser extends ScrobbleParser {
 		}
 
 		const title = showTitle ?? titleElement?.textContent ?? '';
-		const episodeTitle = '';
-		const season = parseInt(seasonId ?? '') || 0;
-		const episode = parseInt(episodeId ?? '') || 0;
-		const type = seasonId ? 'show' : 'movie';
 
-		if (!titleElement) {
-			return null;
+		if (seasonId) {
+			const season = parseInt(seasonId ?? '') || 0;
+			const number = parseInt(episodeId ?? '') || 0;
+
+			return new EpisodeItem({
+				serviceId,
+				id,
+				title: '',
+				season,
+				number,
+				show: {
+					serviceId,
+					title,
+				},
+			});
 		}
 
-		return new Item({
+		return new MovieItem({
 			serviceId,
 			id,
-			type,
 			title,
-			episodeTitle,
-			season,
-			episode,
 		});
 	}
 }

--- a/src/stores/SyncStore.ts
+++ b/src/stores/SyncStore.ts
@@ -1,17 +1,17 @@
 import { Shared } from '@common/Shared';
-import { Item } from '@models/Item';
+import { ScrobbleItem } from '@models/Item';
 
 export interface SyncStoreData {
 	isLoading: boolean;
 	loadQueue: number[];
-	items: Item[];
+	items: ScrobbleItem[];
 	hasReachedEnd: boolean;
 	hasReachedLastSyncDate: boolean;
 }
 
 const syncStores = new Map<string, SyncStore>();
 
-export const getSyncStore = (serviceId: string | null) => {
+export const getSyncStore = (serviceId: string | null): SyncStore => {
 	const storeId = serviceId || 'multiple';
 	if (!syncStores.has(storeId)) {
 		syncStores.set(storeId, new SyncStore(storeId));
@@ -43,7 +43,7 @@ export class SyncStore {
 	}
 
 	async selectAll(): Promise<SyncStore> {
-		const newItems: Item[] = [];
+		const newItems: ScrobbleItem[] = [];
 		for (const item of this.data.items) {
 			if (!item.isSelected && item.isSelectable()) {
 				const newItem = item.clone();
@@ -56,7 +56,7 @@ export class SyncStore {
 	}
 
 	async selectNone(): Promise<SyncStore> {
-		const newItems: Item[] = [];
+		const newItems: ScrobbleItem[] = [];
 		for (const item of this.data.items) {
 			if (item.isSelected) {
 				const newItem = item.clone();
@@ -69,7 +69,7 @@ export class SyncStore {
 	}
 
 	async toggleAll(): Promise<SyncStore> {
-		const newItems: Item[] = [];
+		const newItems: ScrobbleItem[] = [];
 		for (const item of this.data.items) {
 			if (item.isSelected || (!item.isSelected && item.isSelectable())) {
 				const newItem = item.clone();
@@ -81,7 +81,7 @@ export class SyncStore {
 		return this;
 	}
 
-	areItemsMissingWatchedDate() {
+	areItemsMissingWatchedDate(): boolean {
 		let missingCount = 0;
 		return this.data.items.some((item) => {
 			if (item.isMissingWatchedDate()) {
@@ -118,7 +118,7 @@ export class SyncStore {
 	/**
 	 * Updates items for immutability.
 	 */
-	async update(newItems: Item[], doDispatch: boolean): Promise<SyncStore> {
+	async update(newItems: ScrobbleItem[], doDispatch: boolean): Promise<SyncStore> {
 		for (const newItem of newItems) {
 			this.data.items[newItem.index] = newItem;
 		}
@@ -128,11 +128,11 @@ export class SyncStore {
 		return this;
 	}
 
-	async dispatchUpdate(newItems: Item[]): Promise<SyncStore> {
+	async dispatchUpdate(newItems: ScrobbleItem[]): Promise<SyncStore> {
 		if (newItems.length === 0) {
 			return this;
 		}
-		const eventData: Record<number, Item> = {};
+		const eventData: Record<number, ScrobbleItem> = {};
 		for (const newItem of newItems) {
 			eventData[newItem.index] = newItem;
 		}


### PR DESCRIPTION
`Item` and `TraktItem` are now split between `episode`, `show` and `movie`.

This PR has the potential to break a lot of things, because the structure of the models has been changed a bit. But I tested a bit and it seems to be working.