### PR TITLE
When english translation is missing on trakt, episodes are always returned as "Episode X".

### DIFF
--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -309,7 +309,8 @@ class _TraktSearch extends TraktApi {
 			(x) =>
 				x.episode.title &&
 				item.title &&
-				this.formatEpisodeTitle(x.episode.title) === this.formatEpisodeTitle(item.title) &&
+				(this.formatEpisodeTitle(x.episode.title) === this.formatEpisodeTitle(item.title) ||
+					/^Episode \d+$/.test(x.episode.title)) &&
 				(this.formatEpisodeTitle(x.show.title).includes(this.formatEpisodeTitle(item.show.title)) ||
 					this.formatEpisodeTitle(item.title).includes(this.formatEpisodeTitle(x.show.title)))
 		);


### PR DESCRIPTION
This should make better matching on non-english titles.