### PR TITLE
Netflix bug fixes and enhancements

### DIFF
--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -343,7 +343,7 @@ class _TraktSearch extends TraktApi {
 		return title
 			.toLowerCase()
 			.replace(/(?<begin>^|\s)(?:a|an|the)(?<end>\s)/g, '$<begin>$<end>')
-			.replace(/\s/g, '');
+			.replace(/[^\w]/g, '');
 	}
 }
 

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -305,7 +305,7 @@ class _TraktSearch extends TraktApi {
 		showItem: TraktSearchShowItem,
 		episodeItems: TraktSearchEpisodeItem[]
 	): TraktSearchEpisodeItem {
-		const searchItem = episodeItems.find(
+		let searchItem = episodeItems.find(
 			(x) =>
 				x.episode.title &&
 				item.title &&
@@ -314,6 +314,9 @@ class _TraktSearch extends TraktApi {
 				(this.formatEpisodeTitle(x.show.title).includes(this.formatEpisodeTitle(item.show.title)) ||
 					this.formatEpisodeTitle(item.title).includes(this.formatEpisodeTitle(x.show.title)))
 		);
+		if (!searchItem && episodeItems.length > 0) {
+			searchItem = episodeItems[0];
+		}
 		if (!searchItem) {
 			throw new RequestError({
 				status: 404,

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -334,9 +334,9 @@ class _NetflixApi extends ServiceApi {
 		let item: ScrobbleItem;
 		const serviceId = this.id;
 		const { video } = metadata;
-		const id = video.id.toString();
 		const { type, title, year } = video;
 		if (type === 'show') {
+			const id = video.currentEpisode.toString();
 			let episodeInfo: NetflixMetadataShowEpisode | undefined;
 			const seasonInfo = video.seasons.find((currentSeason) =>
 				currentSeason.episodes.find((currentEpisode) => {
@@ -367,10 +367,12 @@ class _NetflixApi extends ServiceApi {
 				number,
 				show: {
 					serviceId,
+					id: video.id.toString(),
 					title,
 				},
 			});
 		} else {
+			const id = video.id.toString();
 			item = new MovieItem({
 				serviceId,
 				id,


### PR DESCRIPTION
Bug fixes:

* Bug that scrobbles wrong episode (fixes #102)
* Bug that detects collections incorrectly (fixes #153)
* Bug that fails to match titles because of special characters

Enhancements:

* Fallback to first episode in response if unable to match by title

For testing:

[chrome.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/8750199/chrome.zip)
[firefox.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/8750200/firefox.zip)