### PR TITLE
Fix bug that happens when trying to correct items

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,6 +47,9 @@
 	"cannotSync": {
 		"message": "Cannot sync items"
 	},
+	"clear": {
+		"message": "Clear"
+	},
 	"clearCaches": {
 		"message": "Clear Caches"
 	},
@@ -138,6 +141,9 @@
 	},
 	"couldNotScrobble": {
 		"message": "Could not scrobble."
+	},
+	"currentCorrection": {
+		"message": "Currently corrected to"
 	},
 	"darkTheme": {
 		"message": "Dark"


### PR DESCRIPTION
Fixes #154 

The error was caused by the fact that corrected items are saved to the sync storage, so that they can be synced across devices, and the sync storage has a limit of bytes per item (`QUOTA_BYTES_PER_ITEM`). So if the user is saving a lot of corrections, they'll reach a point where it'll exceed the limit.

The solution was to `JSON.stringify` the corrections object and split it in several string chunks when it's reached the limit, because this way we can store it easily, and then when we have to load it again we just join all the string chunks and use `JSON.parse` to have the full object.

There are still other limits that are not handled at the moment:

* `MAX_ITEMS`, which in Chrome is `512` (so we can have a maximum number of ~500 chunks)
* `QUOTA_BYTES`, which in Chrome is `102400` (or `~102 KB`)

But they shouldn't be reached easily, unless a user corrects a **ton** of items, so we can deal with that when/if it happens.

I also added an option to clear the current correction to this PR, since previously there was no way to do that, so now you can at least free up the storage a bit by removing some corrections if needed.

For testing:

[chrome.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/8750511/chrome.zip)
[firefox.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/8750513/firefox.zip)