### PR TITLE
Fix bug that does not update watched date and progress for cached history items

### DIFF
--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -216,6 +216,7 @@ export abstract class ServiceApi {
 					if (itemId) {
 						const item = caches.items.get(itemId);
 						if (item) {
+							this.updateItemFromHistory(item, historyItem);
 							tmpItems.push(createScrobbleItem(item));
 						} else {
 							tmpItems.push(null);
@@ -308,6 +309,17 @@ export abstract class ServiceApi {
 	 */
 	convertHistoryItems(historyItems: unknown[]): Promisable<ScrobbleItem[]> {
 		return Promise.resolve([]);
+	}
+
+	/**
+	 * This method is responsible for updating the `watchedAt` and `progress` data for an item from the history,
+	 * when it's retrieved from the cache,
+	 * so that it has up-to-date data.
+	 *
+	 * Should be overridden in the child class.
+	 */
+	updateItemFromHistory(item: ScrobbleItemValues, historyItem: unknown): void {
+		// Do nothing
 	}
 
 	/**

--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -5,7 +5,7 @@ import { Requests, withHeaders } from '@common/Requests';
 import { ScriptInjector } from '@common/ScriptInjector';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
+import { EpisodeItem, MovieItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
 import { SetOptional } from 'type-fest';
 
 export interface AmazonPrimeSession extends ServiceApiSession, AmazonPrimeData {}
@@ -302,6 +302,14 @@ class _AmazonPrimeApi extends ServiceApi {
 		}
 
 		return items;
+	}
+
+	updateItemFromHistory(
+		item: ScrobbleItemValues,
+		historyItem: AmazonPrimeHistoryItem
+	): Promisable<void> {
+		item.watchedAt = Utils.unix(historyItem.watchedAt);
+		item.progress = historyItem.progress;
 	}
 
 	async getItem(id: string): Promise<ScrobbleItem | null> {

--- a/src/services/hbo-max/HboMaxApi.ts
+++ b/src/services/hbo-max/HboMaxApi.ts
@@ -5,7 +5,7 @@ import { Requests, withHeaders } from '@common/Requests';
 import { ScriptInjector } from '@common/ScriptInjector';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
+import { EpisodeItem, MovieItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
 
 export interface HboMaxAuthObj {
 	accessToken: string;
@@ -345,6 +345,14 @@ class _HboMaxApi extends ServiceApi {
 		}
 
 		return items;
+	}
+
+	updateItemFromHistory(
+		item: ScrobbleItemValues,
+		historyItem: HboMaxHistoryItem
+	): Promisable<void> {
+		item.watchedAt = Utils.unix(historyItem.watchedAt);
+		item.progress = historyItem.progress;
 	}
 
 	parseItemMetadata(id: string, itemMetadata: HboMaxItemMetadata) {

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -4,7 +4,7 @@ import { Requests } from '@common/Requests';
 import { ScriptInjector } from '@common/ScriptInjector';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
+import { EpisodeItem, MovieItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
 
 export interface NetflixGlobalObject {
 	appContext: {
@@ -216,6 +216,14 @@ class _NetflixApi extends ServiceApi {
 	async convertHistoryItems(historyItems: NetflixHistoryItem[]) {
 		const historyItemsWithMetadata = await this.getHistoryMetadata(historyItems);
 		return historyItemsWithMetadata.map((historyItem) => this.parseHistoryItem(historyItem));
+	}
+
+	updateItemFromHistory(
+		item: ScrobbleItemValues,
+		historyItem: NetflixHistoryItem
+	): Promisable<void> {
+		item.watchedAt = Utils.unix(historyItem.date);
+		item.progress = Math.ceil((historyItem.bookmark / historyItem.duration) * 100);
 	}
 
 	async getHistoryMetadata(historyItems: NetflixHistoryItem[]) {

--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -2,7 +2,13 @@ import { NrkService } from '@/nrk/NrkService';
 import { ServiceApi } from '@apis/ServiceApi';
 import { Requests, withHeaders } from '@common/Requests';
 import { Utils } from '@common/Utils';
-import { BaseItemValues, EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
+import {
+	BaseItemValues,
+	EpisodeItem,
+	MovieItem,
+	ScrobbleItem,
+	ScrobbleItemValues,
+} from '@models/Item';
 
 export interface NrkGlobalObject {
 	getPlaybackSession: () => NrkSession;
@@ -197,6 +203,11 @@ class _NrkApi extends ServiceApi {
 	convertHistoryItems(historyItems: NrkProgressItem[]) {
 		const promises = historyItems.map((historyItem) => this.parseHistoryItem(historyItem));
 		return Promise.all(promises);
+	}
+
+	updateItemFromHistory(item: ScrobbleItemValues, historyItem: NrkProgressItem): Promisable<void> {
+		item.watchedAt = historyItem.registeredAt ? Utils.unix(historyItem.registeredAt) : undefined;
+		item.progress = historyItem.progress === 'inProgress' ? historyItem.inProgress.percentage : 100;
 	}
 
 	async parseHistoryItem(historyItem: NrkProgressItem): Promise<ScrobbleItem> {

--- a/src/services/viaplay/ViaplayApi.ts
+++ b/src/services/viaplay/ViaplayApi.ts
@@ -3,7 +3,7 @@ import { ServiceApi } from '@apis/ServiceApi';
 import { Requests } from '@common/Requests';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
-import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
+import { EpisodeItem, MovieItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
 
 export interface ViaplayAuthResponse {
 	success: boolean;
@@ -190,6 +190,12 @@ class _ViaplayApi extends ServiceApi {
 	convertHistoryItems(historyItems: ViaplayProduct[]) {
 		const items = historyItems.map((historyItem) => this.parseViaplayProduct(historyItem));
 		return items;
+	}
+
+	updateItemFromHistory(item: ScrobbleItemValues, historyItem: ViaplayProduct): Promisable<void> {
+		const progressInfo = historyItem.user.progress;
+		item.watchedAt = progressInfo?.updated ? Utils.unix(progressInfo.updated) : undefined;
+		item.progress = progressInfo?.elapsedPercent || 0;
 	}
 
 	parseViaplayProduct(product: ViaplayProduct): ScrobbleItem {


### PR DESCRIPTION
Fixes #157 

Cached history items aren't updated until the cache expires, so if a user continues watching an unfinished episode/movie, it will not update the watched date and progress when syncing. History items are cached because in some services additional requests need to be made to retrieve metadata about them.

This PR fixes that by updating only `watchedAt` and `progress` for cached history items, which removes the need to make additional requests for that.

For testing:

[chrome.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/8750578/chrome.zip)
[firefox.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/8750579/firefox.zip)