### PR TITLE
Fix sync storage on Firefox

### DIFF
--- a/src/common/BrowserStorage.ts
+++ b/src/common/BrowserStorage.ts
@@ -577,7 +577,7 @@ class _BrowserStorage {
 	 * and therefore can be saved in the sync storage.
 	 */
 	private async splitChunks(values: Record<string, unknown>): Promise<StorageValues> {
-		const maxSize = browser.storage.sync.QUOTA_BYTES_PER_ITEM;
+		const maxSize = browser.storage.sync.QUOTA_BYTES_PER_ITEM ?? 8192;
 		const newValues: Record<string, unknown> = {};
 		const keysToRemove: string[] = [];
 


### PR DESCRIPTION
Sync storage was broken for me when I just tested on Firefox. This fixes that.