### PR TITLE
Add option to load images

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -228,6 +228,12 @@
 	"loadHistoryError": {
 		"message": "Failed to load history."
 	},
+	"loadImages": {
+		"message": "Load images."
+	},
+	"loadImagesDescription": {
+		"message": "With this option disabled, images for the scrobbling item and for the history items will not be loaded. This is useful for slower connections, where loading images significantly slows down the extension."
+	},
 	"loadTraktHistoryError": {
 		"message": "Failed to load Trakt history."
 	},

--- a/src/apis/CorrectionApi.ts
+++ b/src/apis/CorrectionApi.ts
@@ -44,9 +44,6 @@ class _CorrectionApi {
 	 * If all suggestions have already been loaded, returns the same parameter array, otherwise returns a new array for immutability.
 	 */
 	async loadSuggestions(items: ScrobbleItem[]): Promise<ScrobbleItem[]> {
-		if (!Shared.storage.options.sendReceiveSuggestions) {
-			return items;
-		}
 		const hasLoadedSuggestions = !items.some((item) => typeof item.suggestions === 'undefined');
 		if (hasLoadedSuggestions) {
 			return items;
@@ -109,9 +106,6 @@ class _CorrectionApi {
 	 * Saves a suggestion for an item in the database.
 	 */
 	async saveSuggestion(item: ScrobbleItem, suggestion: Suggestion): Promise<void> {
-		if (!Shared.storage.options.sendReceiveSuggestions) {
-			return;
-		}
 		await Requests.send({
 			method: 'PUT',
 			url: this.SUGGESTIONS_DATABASE_URL,

--- a/src/components/CorrectionDialog.tsx
+++ b/src/components/CorrectionDialog.tsx
@@ -168,7 +168,9 @@ export const CorrectionDialog = (): JSX.Element => {
 			}
 			corrections[databaseId] = suggestion;
 			await Shared.storage.set({ corrections }, true);
-			await CorrectionApi.saveSuggestion(newItem, suggestion);
+			if (Shared.storage.options.sendReceiveSuggestions) {
+				await CorrectionApi.saveSuggestion(newItem, suggestion);
+			}
 			await Shared.events.dispatch(
 				dialog.isScrobblingItem ? 'SCROBBLING_ITEM_CORRECTED' : 'ITEM_CORRECTED',
 				null,

--- a/src/modules/history/components/HistoryList.tsx
+++ b/src/modules/history/components/HistoryList.tsx
@@ -147,8 +147,10 @@ export const HistoryList = (): JSX.Element => {
 			items = await CorrectionApi.loadSuggestions(items);
 			await store.update(items, true);
 		}
-		items = await TmdbApi.loadImages(items);
-		await store.update(items, true);
+		if (Shared.storage.options.loadImages) {
+			items = await TmdbApi.loadImages(items);
+			await store.update(items, true);
+		}
 		return items;
 	};
 

--- a/src/modules/history/components/HistoryList.tsx
+++ b/src/modules/history/components/HistoryList.tsx
@@ -143,8 +143,10 @@ export const HistoryList = (): JSX.Element => {
 
 	const loadData = async (items: ScrobbleItem[]) => {
 		items = await ServiceApi.loadTraktHistory(items, processItem);
-		items = await CorrectionApi.loadSuggestions(items);
-		await store.update(items, true);
+		if (Shared.storage.options.sendReceiveSuggestions) {
+			items = await CorrectionApi.loadSuggestions(items);
+			await store.update(items, true);
+		}
 		items = await TmdbApi.loadImages(items);
 		await store.update(items, true);
 		return items;

--- a/src/modules/popup/pages/PopupHomePage.tsx
+++ b/src/modules/popup/pages/PopupHomePage.tsx
@@ -112,7 +112,9 @@ export const HomePage = (): JSX.Element => {
 			if (Shared.storage.options.sendReceiveSuggestions) {
 				[newItem] = await CorrectionApi.loadSuggestions([newItem]);
 			}
-			[newItem] = await TmdbApi.loadImages([newItem]);
+			if (Shared.storage.options.loadImages) {
+				[newItem] = await TmdbApi.loadImages([newItem]);
+			}
 			setContent((prevContent) => ({
 				...prevContent,
 				scrobblingItem: newItem,


### PR DESCRIPTION
Fixes #182 

Adds an option to disable loading images for slower connections, as images are just for decoration and don't influence in the functionality of the extension.

For testing:

[chrome.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/9690787/chrome.zip)
[firefox.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/9690788/firefox.zip)
