### PR TITLE
Replace setTimeout with alarms

### DIFF
--- a/src/common/AutoSync.ts
+++ b/src/common/AutoSync.ts
@@ -42,8 +42,6 @@ class _AutoSync {
 	private async check() {
 		await Shared.waitForInit();
 
-		console.log('Checking auto sync...');
-
 		const now = Utils.unix();
 		const servicesToSync = getServices().filter((service) => {
 			const value = Shared.storage.options.services[service.id];

--- a/src/common/AutoSync.ts
+++ b/src/common/AutoSync.ts
@@ -2,7 +2,6 @@ import { getServiceApi, ServiceApi } from '@apis/ServiceApi';
 import { TraktSync } from '@apis/TraktSync';
 import { BrowserAction } from '@common/BrowserAction';
 import { StorageValuesOptions } from '@common/BrowserStorage';
-import { StorageOptionsChangeData } from '@common/Events';
 import { I18N } from '@common/I18N';
 import { RequestError } from '@common/RequestError';
 import { Shared } from '@common/Shared';
@@ -12,37 +11,38 @@ import { getServices, Service } from '@models/Service';
 import '@services-apis';
 import { getSyncStore } from '@stores/SyncStore';
 import { PartialDeep } from 'type-fest';
+import browser, { Alarms as WebExtAlarms } from 'webextension-polyfill';
 
 class _AutoSync {
-	isChecking = false;
-	checkTimeoutId: number | null = null;
-
-	init() {
-		void this.check();
-		Shared.events.subscribe('STORAGE_OPTIONS_CHANGE', null, this.onStorageOptionsChange);
-	}
-
-	onStorageOptionsChange = (data: StorageOptionsChangeData) => {
-		if (data.options?.services) {
-			const doCheck = Object.values(data.options.services).some(
-				(serviceValue) =>
-					serviceValue && ('autoSync' in serviceValue || 'autoSyncDays' in serviceValue)
-			);
-			if (doCheck) {
-				void this.check();
-			}
-		}
-	};
-
-	async check() {
-		if (this.isChecking) {
+	async initFromBackground() {
+		const existingAlarm = await browser.alarms.get('check-auto-sync');
+		if (existingAlarm) {
 			return;
 		}
-		this.isChecking = true;
 
-		if (this.checkTimeoutId !== null) {
-			window.clearTimeout(this.checkTimeoutId);
+		browser.alarms.create('check-auto-sync', {
+			delayInMinutes: 1,
+			// Check again every hour
+			periodInMinutes: 60,
+		});
+	}
+
+	addBackgroundListeners() {
+		browser.alarms.onAlarm.addListener(this.onAlarm);
+	}
+
+	private onAlarm = (alarm: WebExtAlarms.Alarm) => {
+		if (alarm.name !== 'check-auto-sync') {
+			return;
 		}
+
+		void this.check();
+	};
+
+	private async check() {
+		await Shared.waitForInit();
+
+		console.log('Checking auto sync...');
 
 		const now = Utils.unix();
 		const servicesToSync = getServices().filter((service) => {
@@ -70,11 +70,6 @@ class _AutoSync {
 			await BrowserAction.setTitle();
 			await BrowserAction.setStaticIcon();
 		}
-
-		// Check again every hour
-		this.checkTimeoutId = window.setTimeout(() => void this.check(), 3600000);
-
-		this.isChecking = false;
 	}
 
 	private async sync(services: Service[], now: number) {

--- a/src/common/Cache.ts
+++ b/src/common/Cache.ts
@@ -6,6 +6,7 @@ import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
 import { ScrobbleItemValues } from '@models/Item';
 import { TraktItemValues } from '@models/TraktItem';
+import browser, { Alarms as WebExtAlarms } from 'webextension-polyfill';
 
 export type CacheItems<T extends (keyof CacheValues)[]> = {
 	[K in T[number]]: CacheItem<K>;
@@ -89,28 +90,41 @@ class _Cache {
 		urlsToTraktItems: 24 * 60 * 60,
 	};
 
-	private isChecking = false;
-	private checkTimeout: number | null = null;
-
 	readonly storageKeys = Object.keys(this.ttl).map(
 		(key) => `${key}Cache`
 	) as (keyof CacheStorageValues)[];
 
 	timestamp = 0;
 
-	init() {
-		void this.check();
-	}
-
-	async check() {
-		if (this.isChecking) {
+	async initFromBackground() {
+		const existingAlarm = await browser.alarms.get('check-cache');
+		if (existingAlarm) {
 			return;
 		}
-		this.isChecking = true;
 
-		if (this.checkTimeout !== null) {
-			window.clearTimeout(this.checkTimeout);
+		browser.alarms.create('check-cache', {
+			delayInMinutes: 1,
+			// Check again every hour
+			periodInMinutes: 60,
+		});
+	}
+
+	addBackgroundListeners() {
+		browser.alarms.onAlarm.addListener(this.onAlarm);
+	}
+
+	private onAlarm = (alarm: WebExtAlarms.Alarm) => {
+		if (alarm.name !== 'check-cache') {
+			return;
 		}
+
+		void this.check();
+	};
+
+	private async check() {
+		await Shared.waitForInit();
+
+		console.log('Checking cache...');
 
 		const now = Utils.unix();
 		for (const [key, ttl] of Object.entries(this.ttl) as [keyof CacheValues, number][]) {
@@ -127,11 +141,6 @@ class _Cache {
 			}
 			await Shared.storage.set({ [storageKey]: cache }, false);
 		}
-
-		// Check again every hour
-		this.checkTimeout = window.setTimeout(() => void this.check(), 3600000);
-
-		this.isChecking = false;
 	}
 
 	async get<K extends keyof CacheValues>(key: K): Promise<CacheItem<K>>;

--- a/src/common/Cache.ts
+++ b/src/common/Cache.ts
@@ -124,8 +124,6 @@ class _Cache {
 	private async check() {
 		await Shared.waitForInit();
 
-		console.log('Checking cache...');
-
 		const now = Utils.unix();
 		for (const [key, ttl] of Object.entries(this.ttl) as [keyof CacheValues, number][]) {
 			const storageKey = `${key}Cache` as const;

--- a/src/common/Shared.ts
+++ b/src/common/Shared.ts
@@ -21,6 +21,9 @@ export interface SharedValues {
 	storage: typeof BrowserStorage;
 	errors: typeof Errors;
 	events: typeof EventDispatcher;
+
+	waitForInit: () => Promise<unknown>;
+	finishInit: () => void;
 }
 
 export type BrowserPrefix = 'moz' | 'chrome' | 'unknown';
@@ -37,6 +40,12 @@ const browsers: Record<BrowserPrefix, BrowserName> = {
 const browserPrefix = browser
 	? (browser.runtime.getURL('/').split('-')[0] as BrowserPrefix)
 	: 'unknown';
+
+let initPromiseResolve: (value: unknown) => void = () => {
+	// Do nothing
+};
+
+const initPromise = new Promise((resolve) => (initPromiseResolve = resolve));
 
 export const Shared: SharedValues = {
 	DATABASE_URL: 'https://uts.rafaelgomes.xyz/api',
@@ -55,4 +64,7 @@ export const Shared: SharedValues = {
 	storage: {} as typeof BrowserStorage,
 	errors: {} as typeof Errors,
 	events: {} as typeof EventDispatcher,
+
+	waitForInit: () => initPromise,
+	finishInit: () => initPromiseResolve(null),
 };

--- a/src/modules/background/background.ts
+++ b/src/modules/background/background.ts
@@ -19,6 +19,9 @@ import '@images/uts-icon-38.png';
 import '@images/uts-icon-selected-19.png';
 import '@images/uts-icon-selected-38.png';
 
+Cache.addBackgroundListeners();
+AutoSync.addBackgroundListeners();
+
 const init = async () => {
 	Shared.pageType = 'background';
 	await BrowserStorage.init();
@@ -28,9 +31,10 @@ const init = async () => {
 	Notifications.init();
 	RequestsManager.init();
 	ScriptInjector.init();
-	Cache.init();
-	AutoSync.init();
+	await Cache.initFromBackground();
+	await AutoSync.initFromBackground();
 	Messaging.init();
+	Shared.finishInit();
 };
 
 Messaging.addHandlers({

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -260,6 +260,7 @@ const getManifest = (browserName: string): string => {
 			default_title: 'Universal Trakt Scrobbler',
 		},
 		permissions: [
+			'alarms',
 			'identity',
 			'storage',
 			'unlimitedStorage',


### PR DESCRIPTION
This begins the effort of making the code compatible with Manifest v3 (https://github.com/trakt-tools/universal-trakt-scrobbler/issues/156), so it's easier to upgrade to it.

`alarms` doesn't require the background page to keep running, so it solves the issue of having to trigger cache / auto sync checks every 60 minutes.