### PR TITLE
Add Tet TV+ service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,27 +55,28 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 <!-- services-start -->
 <!-- Update this section with `npx trakt-tools dev update-readme` -->
 
-| Streaming Service | Scrobble | Sync | Limitations                     |
-| :---------------: | :------: | :--: | :------------------------------ |
-|   Amazon Prime    |    ✔️    |  ✔️  | -                               |
-|       AMC+        |    ✔️    |  ❌  | -                               |
-| Crunchyroll Beta  |    ❌    |  ✔️  | Can't identify movies as movies |
-|      Disney+      |    ✔️    |  ❌  | -                               |
-|     GoPlay BE     |    ✔️    |  ❌  | -                               |
-|      HBO Go       |    ✔️    |  ❌  | -                               |
-|      HBO Max      |    ✔️    |  ✔️  | -                               |
-|      Hotstar      |    ✔️    |  ❌  | -                               |
-|      Kijk.nl      |    ✔️    |  ❌  | -                               |
-|      Netflix      |    ✔️    |  ✔️  | -                               |
-|        NRK        |    ✔️    |  ✔️  | -                               |
-|     Player.pl     |    ✔️    |  ❌  | -                               |
-|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                               |
-|       Star+       |    ✔️    |  ❌  | -                               |
-|    Streamz BE     |    ✔️    |  ❌  | -                               |
-|      Viaplay      |    ✔️    |  ✔️  | -                               |
-|     VRTNu BE      |    ✔️    |  ❌  | -                               |
-|     VTMGo BE      |    ✔️    |  ❌  | -                               |
-|    Wakanim.tv     |    ✔️    |  ❌  | -                               |
+| Streaming Service | Scrobble | Sync | Limitations |
+| :---------------: | :------: | :--: | :---------- |
+|   Amazon Prime    |    ✔️    |  ✔️  | -           |
+|       AMC+        |    ✔️    |  ❌  | -           |
+| Crunchyroll Beta  |    ❌    |  ✔️  | -           |
+|      Disney+      |    ✔️    |  ❌  | -           |
+|     GoPlay BE     |    ✔️    |  ❌  | -           |
+|      HBO Go       |    ✔️    |  ❌  | -           |
+|      HBO Max      |    ✔️    |  ✔️  | -           |
+|      Hotstar      |    ✔️    |  ❌  | -           |
+|      Kijk.nl      |    ✔️    |  ❌  | -           |
+|      Netflix      |    ✔️    |  ✔️  | -           |
+|        NRK        |    ✔️    |  ✔️  | -           |
+|     Player.pl     |    ✔️    |  ❌  | -           |
+|  Polsatboxgo.pl   |    ✔️    |  ❌  | -           |
+|       Star+       |    ✔️    |  ❌  | -           |
+|    Streamz BE     |    ✔️    |  ❌  | -           |
+|      Tet TV+      |    ✔️    |  ❌  | -           |
+|      Viaplay      |    ✔️    |  ✔️  | -           |
+|     VRTNu BE      |    ✔️    |  ❌  | -           |
+|     VTMGo BE      |    ✔️    |  ❌  | -           |
+|    Wakanim.tv     |    ✔️    |  ❌  | -           |
 
 <!-- services-end -->
 

--- a/README.md
+++ b/README.md
@@ -55,28 +55,28 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 <!-- services-start -->
 <!-- Update this section with `npx trakt-tools dev update-readme` -->
 
-| Streaming Service | Scrobble | Sync | Limitations |
-| :---------------: | :------: | :--: | :---------- |
-|   Amazon Prime    |    ✔️    |  ✔️  | -           |
-|       AMC+        |    ✔️    |  ❌  | -           |
-| Crunchyroll Beta  |    ❌    |  ✔️  | -           |
-|      Disney+      |    ✔️    |  ❌  | -           |
-|     GoPlay BE     |    ✔️    |  ❌  | -           |
-|      HBO Go       |    ✔️    |  ❌  | -           |
-|      HBO Max      |    ✔️    |  ✔️  | -           |
-|      Hotstar      |    ✔️    |  ❌  | -           |
-|      Kijk.nl      |    ✔️    |  ❌  | -           |
-|      Netflix      |    ✔️    |  ✔️  | -           |
-|        NRK        |    ✔️    |  ✔️  | -           |
-|     Player.pl     |    ✔️    |  ❌  | -           |
-|  Polsatboxgo.pl   |    ✔️    |  ❌  | -           |
-|       Star+       |    ✔️    |  ❌  | -           |
-|    Streamz BE     |    ✔️    |  ❌  | -           |
-|      Tet TV+      |    ✔️    |  ❌  | -           |
-|      Viaplay      |    ✔️    |  ✔️  | -           |
-|     VRTNu BE      |    ✔️    |  ❌  | -           |
-|     VTMGo BE      |    ✔️    |  ❌  | -           |
-|    Wakanim.tv     |    ✔️    |  ❌  | -           |
+| Streaming Service | Scrobble | Sync | Limitations                     |
+| :---------------: | :------: | :--: | :------------------------------ |
+|   Amazon Prime    |    ✔️    |  ✔️  | -                               |
+|       AMC+        |    ✔️    |  ❌  | -                               |
+| Crunchyroll Beta  |    ❌    |  ✔️  | Can't identify movies as movies |
+|      Disney+      |    ✔️    |  ❌  | -                               |
+|     GoPlay BE     |    ✔️    |  ❌  | -                               |
+|      HBO Go       |    ✔️    |  ❌  | -                               |
+|      HBO Max      |    ✔️    |  ✔️  | -                               |
+|      Hotstar      |    ✔️    |  ❌  | -                               |
+|      Kijk.nl      |    ✔️    |  ❌  | -                               |
+|      Netflix      |    ✔️    |  ✔️  | -                               |
+|        NRK        |    ✔️    |  ✔️  | -                               |
+|     Player.pl     |    ✔️    |  ❌  | -                               |
+|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                               |
+|       Star+       |    ✔️    |  ❌  | -                               |
+|    Streamz BE     |    ✔️    |  ❌  | -                               |
+|      Tet TV+      |    ✔️    |  ❌  | -                               |
+|      Viaplay      |    ✔️    |  ✔️  | -                               |
+|     VRTNu BE      |    ✔️    |  ❌  | -                               |
+|     VTMGo BE      |    ✔️    |  ❌  | -                               |
+|    Wakanim.tv     |    ✔️    |  ❌  | -                               |
 
 <!-- services-end -->
 

--- a/src/services/tet-plus/TetPlusApi.ts
+++ b/src/services/tet-plus/TetPlusApi.ts
@@ -1,0 +1,103 @@
+import { ServiceApi } from '@apis/ServiceApi';
+import { TetPlusService } from '@/tet-plus/TetPlusService';
+import { Shared } from '@common/Shared';
+import { EpisodeItem, MovieItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
+import { Requests } from '@common/Requests';
+
+export interface TetPlusSingleMetadataItem {
+	data: {
+		0: TetPlusMetadataShow | TetPlusMetadataMovie;
+	};
+}
+
+export interface TetPlusMetadataGeneric {
+	id: string;
+	attributes: {
+		title: string;
+		year: number;
+	};
+}
+
+export type TetPlusMetadataShow = TetPlusMetadataGeneric & {
+	type: 'series';
+	attributes: {
+		'season-nr': number;
+		'episode-nr': number;
+		'series-id': string;
+		'series-name': string;
+		'episode-name': string;
+	};
+};
+
+export type TetPlusMetadataMovie = TetPlusMetadataGeneric & {
+	type: 'movie';
+};
+
+class _TetPlusApi extends ServiceApi {
+	HOST_URL: string;
+	API_URL: string;
+
+	constructor() {
+		super(TetPlusService.id);
+
+		this.HOST_URL = 'https://manstv.lattelecom.tv';
+		this.API_URL = `${this.HOST_URL}/api/v1.11`;
+	}
+
+	async getItem(id: string): Promise<ScrobbleItem | null> {
+		let item: ScrobbleItem | null = null;
+		try {
+			const responseText = await Requests.send({
+				url: `${this.API_URL}/get/content/vods/${id}?filter[lang]=en`,
+				method: 'GET',
+			});
+			item = this.parseMetadata(JSON.parse(responseText) as TetPlusSingleMetadataItem);
+		} catch (err) {
+			if (Shared.errors.validate(err)) {
+				Shared.errors.error('Failed to get item.', err);
+			}
+		}
+		return item;
+	}
+
+	parseMetadata(metadata: TetPlusSingleMetadataItem): ScrobbleItem {
+		let item: ScrobbleItem;
+		const serviceId = this.id;
+		const { data } = metadata;
+		const { id, type, attributes } = data[0];
+		const { title, year } = attributes;
+
+		if (type === 'series') {
+			const season = attributes['season-nr'];
+			const number = attributes['episode-nr'];
+			const episodeTitle = attributes['episode-name'];
+			const seriesTitle = attributes['series-name'];
+			const seriesId = attributes['series-id'];
+
+			item = new EpisodeItem({
+				serviceId,
+				id,
+				title: episodeTitle,
+				year,
+				season,
+				number,
+				show: {
+					serviceId,
+					id: seriesId,
+					title: seriesTitle,
+				},
+			});
+		} else {
+			item = new MovieItem({
+				serviceId,
+				id,
+				title,
+				year,
+			});
+		}
+
+		return item;
+	}
+}
+
+export const TetPlusApi = new _TetPlusApi();

--- a/src/services/tet-plus/TetPlusParser.ts
+++ b/src/services/tet-plus/TetPlusParser.ts
@@ -1,0 +1,12 @@
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { TetPlusApi } from '@/tet-plus/TetPlusApi';
+
+class _TetPlusParser extends ScrobbleParser {
+	constructor() {
+		super(TetPlusApi, {
+			watchingUrlRegex: /\/watch\/(?<id>\d+)/, // https://tet.plus/watch/1656568171208 => 1656568171208
+		});
+	}
+}
+
+export const TetPlusParser = new _TetPlusParser();

--- a/src/services/tet-plus/TetPlusService.ts
+++ b/src/services/tet-plus/TetPlusService.ts
@@ -1,0 +1,11 @@
+import { Service } from '@models/Service';
+
+export const TetPlusService = new Service({
+	id: 'tet-plus',
+	name: 'Tet TV+',
+	homePage: 'https://tet.plus/',
+	hostPatterns: ['*://*.tet.plus/*'],
+	hasScrobbler: true,
+	hasSync: false,
+	hasAutoSync: false,
+});

--- a/src/services/tet-plus/tet-plus.ts
+++ b/src/services/tet-plus/tet-plus.ts
@@ -1,0 +1,4 @@
+import { init } from '@service';
+import '@/tet-plus/TetPlusParser';
+
+void init('tet-plus');


### PR DESCRIPTION
Adding Tet TV+ (https://tet.plus/), one of the largest streaming services in Latvia, including HBO content

Here are screenshots of scrobble working for both TV and movies:
![Tet_Movie](https://user-images.githubusercontent.com/70920705/209940794-40644f53-4775-4f90-b62c-fda470f63d2a.jpg)
![Tet_Series](https://user-images.githubusercontent.com/70920705/209940800-c54b8c3d-2190-42df-85f7-481ea5b5e2e6.jpg)

Here are the builds:
- [chrome.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/10319001/chrome.zip)
- [firefox.zip](https://github.com/trakt-tools/universal-trakt-scrobbler/files/10318997/firefox.zip)

This is my first time working on a project like this, so please let me know if there are any issues or if I could've done something better.