### PR TITLE
Fix error when Netflix is missing episode 'summary' field

### DIFF
--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -328,7 +328,7 @@ class _NetflixApi extends ServiceApi {
 			// `hiddenEpisodeNumbers` is `true` for collections
 			// In this case, the episode should be searched by title instead of season and number,
 			// because the numbering differs between Netflix and Trakt.tv for collections
-			if (!historyItem.season?.summary.hiddenEpisodeNumbers) {
+			if (historyItem.season?.summary.hiddenEpisodeNumbers === false) {
 				season = historyItem.summary.season || 0;
 				number = historyItem.summary.episode || 0;
 			}


### PR DESCRIPTION
Resolves #202 and #207.

When a show is removed from Netflix it no longer returns the `summary` field and the extension throws an error like `TypeError: Cannot read properties of undefined (reading 'season')` on the following line:

https://github.com/trakt-tools/universal-trakt-scrobbler/blob/eb0cea31f9f510cee4e0f134380bdcee2820a375/src/services/netflix/NetflixApi.ts#L332

In my case, the show A.P. Bio was the cause of the issue as it has been removed from Netflix.

The `historyItem` looked like this in my case:
```json
"historyItem": {
    "bookmark": 1288,
    "country": "AU",
    "date": 1651909709871,
    "dateStr": "5/7/22",
    "deviceType": 2402,
    "duration": 1260,
    "episodeTitle": "Selling Out",
    "estRating": "30",
    "index": 395,
    "movieID": 81468758,
    "seasonDescriptor": "A.P. Bio",
    "series": 80177453,
    "seriesTitle": "A.P. Bio",
    "title": "\"Selling Out\"",
    "topNodeId": "80177453",
    "videoTitle": "Selling Out",
    "releaseYear": 2018
}
```

The code change:
When `historyItem.season` was undefined the whole expression became `!undefined` which is always true. Added an explicit `=== false` comparison to resolve this.

With this change I was able to sync episodes of the offending show like nothing ever happened.