### PR TITLE
Don't wrap episode titles in History

### DIFF
--- a/src/modules/history/components/HistoryListItemCard.tsx
+++ b/src/modules/history/components/HistoryListItemCard.tsx
@@ -132,7 +132,14 @@ export const HistoryListItemCard = ({
 									{item.season > 0 && item.number > 0 && (
 										<Typography variant="overline">{`S${item.season} E${item.number}`}</Typography>
 									)}
-									<Typography variant="h6">{item.title}</Typography>
+									<Typography
+										variant="h6"
+										noWrap
+										style={{ overflow: 'hidden', textOverflow: 'ellipsis', width: '100%' }}
+										title={item.title}
+									>
+										{item.title}
+									</Typography>
 									<Typography variant="subtitle2">{item.show.title}</Typography>
 									<HistoryListItemDivider useDarkMode={hasImage} />
 									{watchedAtComponent}


### PR DESCRIPTION
Resolves #241

Changes: 
- Disabled text wrapping on episode titles and added the necessary styling. 
- Added title tag to see the full episode name on hover.

While dynamically resizing the row of cards to fit all of the information would be a better solution, I couldn't figure it out without quite large changes like relying on JS to resize that after load. 
I think this works quite well for now and allows full use of the extension.

Before:
![before](https://user-images.githubusercontent.com/70920705/210964583-b749e1f3-2567-4160-8473-ef5c133103b0.png)

After:
![after](https://user-images.githubusercontent.com/70920705/210964600-6dd3a791-bb7c-436a-848e-65a952a874f5.png)
