### PR TITLE
Add support for Prime bonus content

### DIFF
--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -84,7 +84,7 @@ export interface AmazonPrimeEnrichmentsResponse {
 export interface AmazonPrimeMetadataItem {
 	catalogMetadata: {
 		catalog: {
-			entityType: 'TV Show' | 'Movie';
+			entityType: 'TV Show' | 'Movie' | 'Trailer' | 'Bonus Content';
 			episodeNumber?: number;
 			id: string;
 			title: string;
@@ -366,8 +366,8 @@ class _AmazonPrimeApi extends ServiceApi {
 		const serviceId = this.id;
 		const { catalog, family } = metadata.catalogMetadata;
 		const { id, entityType } = catalog;
-		const type = entityType === 'TV Show' ? 'show' : 'movie';
-		if (type === 'show') {
+
+		if (entityType === 'TV Show' || entityType === 'Bonus Content') {
 			let title = '';
 			let season = 0;
 			if (family) {


### PR DESCRIPTION
Added Bonus Content to episode logic, this allows to sync Prime Bonus content with Specials on Trakt. 

Previously bonus content was handled as movie by default, which led to no matches found or incorrect matches (while testing I saw a Rammstein concert as a match for one of the bonus videos).

Found the two new entityTypes after looking into #242.

Before:
![image](https://user-images.githubusercontent.com/70920705/211045007-07213a97-298f-482d-afa1-a99f870a6791.png)

After:
![image](https://user-images.githubusercontent.com/70920705/211044478-da401971-8fbb-49ff-b0c0-14ee26e0a0fe.png)
