### PR TITLE
Fixes history in Firefox containers + some small additional changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Never delete the `translations` branch after merging PRs from Crowdin, as Crowdi
 1. Create an application in the [Trakt API](https://trakt.tv/oauth/applications/new) (don't forget to check the `/scrobble` permission).
 2. In `Redirect uri:`, put `https://trakt.tv/apps`.
 3. In `Javascript (cors) origins:`, put `moz-extension://` and `chrome-extension://`.
-4. Copy the `.env.example` example file and change the Trakt.tv credentials.
+4. Copy the `.env.example` example file and change the Trakt.tv credentials. Make sure to also set the extension ID to an arbitrary but unique string, otherwise some browser features might not be available to the extension.
 
 ```bash
 cp .env.example .env

--- a/src/common/Messaging.ts
+++ b/src/common/Messaging.ts
@@ -241,13 +241,17 @@ class _Messaging {
 			response = ((await browser.runtime.sendMessage(message)) ?? null) as ReturnType<T>;
 		} catch (err) {
 			if (err instanceof Error) {
-				const messagingError = JSON.parse(err.message) as MessagingError;
-				switch (messagingError.instance) {
-					case 'Error':
-						throw new Error(messagingError.data.message);
+				try {
+					const messagingError = JSON.parse(err.message) as MessagingError;
+					switch (messagingError.instance) {
+						case 'Error':
+							throw new Error(messagingError.data.message);
 
-					case 'RequestError':
-						throw new RequestError(messagingError.data);
+						case 'RequestError':
+							throw new RequestError(messagingError.data);
+					}
+				} catch (_) {
+					throw err;
 				}
 			}
 		}

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -150,7 +150,7 @@ class _Requests {
 		if (!Shared.storage.options.grantCookies || !browser.cookies || !browser.webRequest) {
 			return;
 		}
-		const domainMatches = /https?:\/\/(?:www\.)?(?:.+?)(?<domain>\/.*)?$/.exec(request.url);
+		const domainMatches = /https?:\/\/(?:www\.)?(?<domain>.+?)(?:\/.*)?$/.exec(request.url);
 		if (!domainMatches?.groups) {
 			return;
 		}

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -188,7 +188,7 @@ class _NetflixApi extends ServiceApi {
 				});
 				this.session = this.extractSession(responseText);
 			}
-			if (this.session && this.session.profileName) {
+			if (this.session?.profileName != null) {
 				this.isActivated = true;
 			}
 		} catch (err) {
@@ -203,7 +203,7 @@ class _NetflixApi extends ServiceApi {
 		if (!this.isActivated) {
 			await this.activate();
 		}
-		return !!this.session && this.session.profileName !== null;
+		return this.session?.profileName != null;
 	}
 
 	async loadHistoryItems(): Promise<NetflixHistoryItem[]> {

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -188,7 +188,7 @@ class _NetflixApi extends ServiceApi {
 				});
 				this.session = this.extractSession(responseText);
 			}
-			if (this.session) {
+			if (this.session && this.session.profileName) {
 				this.isActivated = true;
 			}
 		} catch (err) {


### PR DESCRIPTION
This mainly fixes https://github.com/trakt-tools/universal-trakt-scrobbler/issues/252.  
The issue occurred, because the regex pattern to get the domain part of the URL actually got the path.

In addition, it has some other minor improvements:

- Added a comment to the readme in the development section to also add an extension ID, because otherwise the messaging is unavailable.
- Added fallback in messaging error handling in case of the error not actually being a JSON string. It will now return the original error, which would otherwise be hard to get and debug.
- Only sets the `isActivated` flag for Netflix if it has a profile name. Otherwise, you are stuck with an invalid session, while the `activate()` method will no longer be called. The session object is still set, even when Netflix is not logged in, hence only the profile name can help check, whether the user is _actually_ logged in