### PR TITLE
Updates the name of cli from trakt-tools to @trakt-tools/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 ### Which streaming services are supported?
 
 <!-- services-start -->
-<!-- Update this section with `npx trakt-tools dev update-readme` -->
+<!-- Update this section with `npx @trakt-tools/cli dev update-readme` -->
 
 | Streaming Service | Scrobble | Sync | Limitations                     |
 | :---------------: | :------: | :--: | :------------------------------ |
@@ -152,12 +152,12 @@ pnpm run zip
 
 #### How to add more streaming services
 
-- Run `npx trakt-tools dev create-service`. It will prompt you a few questions about the service and automatically generate all the necessary files. If you want to provide all the information at once without being prompted, run `npx trakt-tools dev create-service --help` to see the options.
+- Run `npx @trakt-tools/cli dev create-service`. It will prompt you a few questions about the service and automatically generate all the necessary files. If you want to provide all the information at once without being prompted, run `npx @trakt-tools/cli dev create-service --help` to see the options.
 - Go to the generated files and adjust them accordingly. You can see the files of the other services for some reference.
 
 #### How to add scrobbler/sync to streaming services
 
-- If a service is missing either the scrobbler or the sync function, you can run `npx trakt-tools dev update-service` to automatically generate all the missing files.
+- If a service is missing either the scrobbler or the sync function, you can run `npx @trakt-tools/cli dev update-service` to automatically generate all the missing files.
 
 ### Credits
 


### PR DESCRIPTION
Updates the README to contain the correct CLI package name