### PR TITLE
Make compatible with Manifest v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
 		"@mui/material": "^5.10.16",
 		"@mui/system": "^5.10.16",
 		"@mui/x-date-pickers": "^5.0.9",
-		"@rafaelgomesxyz/axios-rate-limit": "^1.3.1",
-		"axios": "^0.26.1",
 		"date-fns": "^2.29.3",
 		"deepmerge": "^4.2.2",
 		"history": "^4.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,6 @@ specifiers:
   '@mui/system': ^5.10.16
   '@mui/x-date-pickers': ^5.0.9
   '@octokit/rest': ^19.0.5
-  '@rafaelgomesxyz/axios-rate-limit': ^1.3.1
   '@trakt-tools/cli': ^0.3.3
   '@types/archiver': ^5.3.1
   '@types/circular-dependency-plugin': ^5.0.5
@@ -35,7 +34,6 @@ specifiers:
   '@typescript-eslint/eslint-plugin': ^5.45.0
   '@typescript-eslint/parser': ^5.45.0
   archiver: ^5.3.1
-  axios: ^0.26.1
   babel-loader: ^9.1.0
   babel-preset-minify: ^0.5.2
   circular-dependency-plugin: ^5.2.2
@@ -85,8 +83,6 @@ dependencies:
   '@mui/material': 5.10.16_dcb5dvvtsx36mkhj3zatp75czu
   '@mui/system': 5.10.16_744ksytjc5r2ljn2ycwqyqkjji
   '@mui/x-date-pickers': 5.0.9_5jl2rg5of4rymsbngywpgdy2vy
-  '@rafaelgomesxyz/axios-rate-limit': 1.3.1_axios@0.26.1
-  axios: 0.26.1
   date-fns: 2.29.3
   deepmerge: 4.2.2
   history: 4.10.1
@@ -2159,14 +2155,6 @@ packages:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
 
-  /@rafaelgomesxyz/axios-rate-limit/1.3.1_axios@0.26.1:
-    resolution: {integrity: sha512-eSLiUDBvaR93CS23pWCy4elPzWV9w6W65IJFrNT3Pg4ay8XYAxo45goBl3fxV0fKcXGglIKl/2z1osspKMGHwg==}
-    peerDependencies:
-      axios: '*'
-    dependencies:
-      axios: 0.26.1
-    dev: false
-
   /@trakt-tools/cli/0.3.3:
     resolution: {integrity: sha512-EsR3W6mOCojii3KqL7hjAwq8Rv8GgFi7H/awEEKEUKjzFmy82wvUGNcjrdshHQMp450oM/NvNd5AVbdRVMi/vQ==}
     hasBin: true
@@ -2845,14 +2833,6 @@ packages:
 
   /async/3.2.4:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
-
-  /axios/0.26.1:
-    resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
-    dependencies:
-      follow-redirects: 1.14.9
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
   /babel-helper-evaluate-path/0.5.0:
     resolution: {integrity: sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==}
@@ -4134,16 +4114,6 @@ packages:
   /flatted/3.1.1:
     resolution: {integrity: sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==}
     dev: true
-
-  /follow-redirects/1.14.9:
-    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
 
   /fs-constants/1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}

--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -136,7 +136,8 @@ export abstract class ServiceApi {
 	async loadHistory(
 		itemsToLoad: number,
 		lastSync: number,
-		lastSyncId: string
+		lastSyncId: string,
+		cancelKey = 'default'
 	): Promise<ScrobbleItem[]> {
 		let items: ScrobbleItem[] = [];
 		try {
@@ -156,7 +157,7 @@ export abstract class ServiceApi {
 					responseItems = this.leftoverHistoryItems;
 					this.leftoverHistoryItems = [];
 				} else if (!this.hasReachedHistoryEnd) {
-					responseItems = await this.loadHistoryItems();
+					responseItems = await this.loadHistoryItems(cancelKey);
 					if (!this.hasCheckedHistoryCache) {
 						let firstItem: ScrobbleItemValues | null = null;
 						if (historyCache.items.length > 0) {
@@ -282,7 +283,7 @@ export abstract class ServiceApi {
 	 *
 	 * Should be overridden in the child class.
 	 */
-	loadHistoryItems(): Promise<unknown[]> {
+	loadHistoryItems(cancelKey = 'default'): Promise<unknown[]> {
 		Shared.errors.error('loadHistoryItems() is not implemented in this service!', new Error());
 		return Promise.resolve([]);
 	}

--- a/src/apis/TraktApi.ts
+++ b/src/apis/TraktApi.ts
@@ -1,4 +1,4 @@
-import { withHeaders, withRateLimit } from '@common/Requests';
+import { Requests, withHeaders } from '@common/Requests';
 import { Shared } from '@common/Shared';
 
 export class TraktApi {
@@ -15,17 +15,7 @@ export class TraktApi {
 	SYNC_URL: string;
 	SETTINGS_URL: string;
 
-	requests = withRateLimit({
-		id: 'trakt-api',
-
-		/**
-		 * @see https://trakt.docs.apiary.io/#introduction/rate-limiting
-		 */
-		maxRPS: {
-			'*': 1,
-			GET: 3,
-		},
-	});
+	requests = Requests;
 
 	isActivated = false;
 

--- a/src/apis/TraktAuth.ts
+++ b/src/apis/TraktAuth.ts
@@ -30,6 +30,10 @@ class _TraktAuth extends TraktApi {
 		this.manualAuth = {};
 	}
 
+	requiresCookies(): boolean {
+		return Shared.browser === 'firefox' ? !!Shared.storage.options.grantCookies : false;
+	}
+
 	getAuthorizeUrl(): string {
 		return `${this.AUTHORIZE_URL}?response_type=code&client_id=${
 			Shared.clientId
@@ -37,8 +41,7 @@ class _TraktAuth extends TraktApi {
 	}
 
 	getRedirectUrl(): string {
-		const requiresCookies = !!Shared.storage.options.grantCookies;
-		return this.isIdentityAvailable && !requiresCookies
+		return this.isIdentityAvailable && !this.requiresCookies()
 			? browser.identity.getRedirectURL()
 			: this.REDIRECT_URL;
 	}
@@ -54,11 +57,7 @@ class _TraktAuth extends TraktApi {
 
 	authorize(): Promise<TraktAuthDetails> {
 		let promise: Promise<TraktAuthDetails>;
-		let requiresCookies = false;
-		if (Shared.browser === 'firefox') {
-			requiresCookies = !!Shared.storage.options.grantCookies;
-		}
-		if (this.isIdentityAvailable && !requiresCookies) {
+		if (this.isIdentityAvailable && !this.requiresCookies()) {
 			promise = this.startIdentityAuth();
 		} else {
 			promise = new Promise<TraktAuthDetails>((resolve) => void this.startManualAuth(resolve));

--- a/src/apis/TraktScrobble.ts
+++ b/src/apis/TraktScrobble.ts
@@ -44,7 +44,7 @@ class _TraktScrobble extends TraktApi {
 		}
 		await this.send(item.trakt, this.START);
 		let { scrobblingDetails } = await Shared.storage.get('scrobblingDetails');
-		if (scrobblingDetails) {
+		if (scrobblingDetails?.tabId === Shared.tabId) {
 			scrobblingDetails.isPaused = false;
 		} else {
 			scrobblingDetails = {

--- a/src/apis/TraktSync.ts
+++ b/src/apis/TraktSync.ts
@@ -1,6 +1,5 @@
 import { TraktApi } from '@apis/TraktApi';
 import { Cache, CacheItem } from '@common/Cache';
-import { RequestPriority } from '@common/Requests';
 import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
 import { ScrobbleItem } from '@models/Item';
@@ -56,7 +55,6 @@ class _TraktSync extends TraktApi {
 				url: this.getUrl(item),
 				method: 'GET',
 				cancelKey,
-				priority: RequestPriority.HIGH,
 			});
 			historyItems = JSON.parse(responseText) as TraktHistoryItem[];
 			traktHistoryItemsCache.set(databaseId, historyItems);

--- a/src/common/AutoSync.ts
+++ b/src/common/AutoSync.ts
@@ -93,7 +93,7 @@ class _AutoSync {
 			await store.resetData();
 
 			try {
-				await api.loadHistory(Infinity, serviceValue.lastSync, serviceValue.lastSyncId);
+				await api.loadHistory(Infinity, serviceValue.lastSync, serviceValue.lastSyncId, 'autoSync');
 
 				items = store.data.items.filter(
 					(item) => item.progress >= Shared.storage.syncOptions.minPercentageWatched

--- a/src/common/BrowserAction.ts
+++ b/src/common/BrowserAction.ts
@@ -11,6 +11,7 @@ export interface BrowserActionRotating {
 }
 
 class _BrowserAction {
+	instance = Shared.manifestVersion === 3 ? browser.action : browser.browserAction;
 	currentIcon = browser.runtime.getURL('images/uts-icon-38.png');
 	rotating: BrowserActionRotating | null = null;
 
@@ -30,7 +31,7 @@ class _BrowserAction {
 
 	async setTitle(title = 'Universal Trakt Scrobbler'): Promise<void> {
 		if (Shared.pageType === 'background') {
-			await browser.browserAction.setTitle({ title });
+			await this.instance.setTitle({ title });
 		} else {
 			await Messaging.toExtension({ action: 'set-title', title });
 		}
@@ -43,7 +44,7 @@ class _BrowserAction {
 				await this.setStaticIcon();
 				await this.setRotatingIcon();
 			} else {
-				await browser.browserAction.setIcon({
+				await this.instance.setIcon({
 					path: this.currentIcon,
 				});
 			}
@@ -59,7 +60,7 @@ class _BrowserAction {
 				await this.setStaticIcon();
 				await this.setRotatingIcon();
 			} else {
-				await browser.browserAction.setIcon({
+				await this.instance.setIcon({
 					path: this.currentIcon,
 				});
 			}
@@ -114,7 +115,7 @@ class _BrowserAction {
 		context.rotate((degrees * Math.PI) / 180);
 		context.drawImage(image, -(image.width / 2), -(image.height / 2));
 
-		await browser.browserAction.setIcon({
+		await this.instance.setIcon({
 			imageData: context.getImageData(
 				0,
 				0,

--- a/src/common/BrowserStorage.ts
+++ b/src/common/BrowserStorage.ts
@@ -22,7 +22,7 @@ export type StorageValuesV11 = Omit<StorageValuesV10, 'version'> & {
 	version?: 11;
 };
 
-export type StorageValuesV10 = Omit<StorageValuesV8, 'version' | 'options'> & {
+export type StorageValuesV10 = Omit<StorageValuesV9, 'version' | 'options'> & {
 	version?: 10;
 	options?: StorageValuesOptionsV4;
 };

--- a/src/common/Errors.ts
+++ b/src/common/Errors.ts
@@ -39,10 +39,14 @@ class _Errors {
 					environment: Shared.environment,
 				},
 			});
-			window.Rollbar = this.rollbar;
+			if (window) {
+				window.Rollbar = this.rollbar;
+			}
 		} else if (!allowRollbar && this.rollbar) {
 			delete this.rollbar;
-			delete window.Rollbar;
+			if (window) {
+				delete window.Rollbar;
+			}
 		}
 	}
 

--- a/src/common/Messaging.ts
+++ b/src/common/Messaging.ts
@@ -25,6 +25,7 @@ export interface MessageRequests {
 	'dispatch-event': DispatchEventMessage;
 	'send-to-all-content': SendToAllContentMessage;
 	'inject-function': InjectFunctionMessage;
+	'inject-function-from-background': InjectFunctionFromBackgroundMessage;
 }
 
 export type ReturnType<T extends MessageRequest> = ReturnTypes[T['action']];
@@ -46,6 +47,7 @@ export interface ReturnTypes {
 	'dispatch-event': void;
 	'send-to-all-content': void;
 	'inject-function': unknown;
+	'inject-function-from-background': unknown;
 }
 
 export interface OpenTabMessage {
@@ -124,8 +126,12 @@ export interface InjectFunctionMessage {
 	serviceId: string;
 	key: string;
 	url: string;
-	fnStr: string;
-	fnParamsStr: string;
+	params: Record<string, unknown>;
+}
+
+export interface InjectFunctionFromBackgroundMessage extends Omit<InjectFunctionMessage, 'action'> {
+	action: 'inject-function-from-background';
+	tabId: number | null;
 }
 
 export type MessageHandlers = {

--- a/src/common/Messaging.ts
+++ b/src/common/Messaging.ts
@@ -241,17 +241,18 @@ class _Messaging {
 			response = ((await browser.runtime.sendMessage(message)) ?? null) as ReturnType<T>;
 		} catch (err) {
 			if (err instanceof Error) {
+				let messagingError;
 				try {
-					const messagingError = JSON.parse(err.message) as MessagingError;
-					switch (messagingError.instance) {
-						case 'Error':
-							throw new Error(messagingError.data.message);
-
-						case 'RequestError':
-							throw new RequestError(messagingError.data);
-					}
+					messagingError = JSON.parse(err.message) as MessagingError;
 				} catch (_) {
 					throw err;
+				}
+				switch (messagingError.instance) {
+					case 'Error':
+						throw new Error(messagingError.data.message);
+
+					case 'RequestError':
+						throw new RequestError(messagingError.data);
 				}
 			}
 		}

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -51,10 +51,7 @@ class _Requests {
 				const retryAfterStr = response.headers.get('Retry-After');
 				if (retryAfterStr) {
 					const retryAfter = Number.parseInt(retryAfterStr) * 1000;
-					window.setTimeout(
-						() => void this.sendDirectly(request, tabId, resolve, reject),
-						retryAfter
-					);
+					setTimeout(() => void this.sendDirectly(request, tabId, resolve, reject), retryAfter);
 					return;
 				}
 			}

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -2,20 +2,16 @@ import { Messaging } from '@common/Messaging';
 import { RequestError } from '@common/RequestError';
 import { RequestsManager } from '@common/RequestsManager';
 import { Shared } from '@common/Shared';
-import axiosRateLimit from '@rafaelgomesxyz/axios-rate-limit';
-import axios, { AxiosResponse, Method } from 'axios';
 import browser from 'webextension-polyfill';
 
 export type RequestDetails = {
 	url: string;
 	method: string;
 	headers?: Record<string, string>;
-	rateLimit?: RateLimit;
 	body?: unknown;
+	signal?: AbortSignal;
 	cancelKey?: string;
-	priority?: RequestPriority;
 	withHeaders?: Record<string, string>;
-	withRateLimit?: RateLimitConfig;
 };
 
 export interface RequestOptions {
@@ -24,59 +20,44 @@ export interface RequestOptions {
 	body: RequestInit['body'];
 }
 
-export interface RateLimit {
-	id: string;
-	maxRPS: number;
-}
-
-export enum RequestPriority {
-	NORMAL,
-	HIGH,
-}
-
-export interface RateLimitConfig {
-	/** All requests with the same ID will be limited by the same instance. */
-	id: string;
-
-	/** Maximum requests per second. */
-	maxRPS: {
-		/** This limit will apply to all methods, unless a limit for the specific method has been provided. */
-		'*': number;
-
-		/** This limit will apply to the specific method. */
-		[K: string]: number | undefined;
-	};
-}
-
 class _Requests {
 	readonly withHeaders: Record<string, string> = {};
-	readonly withRateLimit: RateLimitConfig = {
-		id: 'default',
-		maxRPS: {
-			'*': 2,
-		},
-	};
 
 	async send(request: RequestDetails, tabId = Shared.tabId): Promise<string> {
-		let responseText = '';
-		if (Shared.pageType === 'background') {
-			responseText = await this.sendDirectly(request, tabId);
-		} else {
-			// All requests from other pages must be sent to the background page so that it can rate limit them
-			request.withHeaders = this.withHeaders;
-			request.withRateLimit = this.withRateLimit;
-			responseText = await Messaging.toExtension({ action: 'send-request', request });
-		}
-		return responseText;
+		return new Promise((resolve, reject) => {
+			if (Shared.pageType === 'background') {
+				void this.sendDirectly(request, tabId, resolve, reject);
+			} else {
+				// All requests from other pages must be sent to the background page to bypass CORS
+				request.withHeaders = this.withHeaders;
+				Messaging.toExtension({ action: 'send-request', request }).then(resolve).catch(reject);
+			}
+		});
 	}
 
-	async sendDirectly(request: RequestDetails, tabId = Shared.tabId): Promise<string> {
+	async sendDirectly(
+		request: RequestDetails,
+		tabId = Shared.tabId,
+		resolve: PromiseResolve<string>,
+		reject: PromiseReject
+	): Promise<void> {
 		let responseStatus = 0;
 		let responseText = '';
 		try {
 			const response = await this.fetch(request, tabId);
 			responseStatus = response.status;
-			responseText = response.data;
+			responseText = await response.text();
+			if (responseStatus === 429) {
+				const retryAfterStr = response.headers.get('Retry-After');
+				if (retryAfterStr) {
+					const retryAfter = Number.parseInt(retryAfterStr) * 1000;
+					window.setTimeout(
+						() => void this.sendDirectly(request, tabId, resolve, reject),
+						retryAfter
+					);
+					return;
+				}
+			}
 			if (responseStatus < 200 || responseStatus >= 400) {
 				throw responseText;
 			}
@@ -94,42 +75,32 @@ class _Requests {
 				if ('status' in err.response) errRespStatus = err.response.status as number;
 				if ('data' in err.response) errRespData = err.response.data as string;
 			}
-			throw new RequestError({
-				request,
-				status: errRespStatus,
-				text: errRespData,
-				isCanceled: err instanceof axios.Cancel,
-			});
+			reject(
+				new RequestError({
+					request,
+					status: errRespStatus,
+					text: errRespData,
+					isCanceled: request.signal?.aborted ?? false,
+				})
+			);
 		}
-		return responseText;
+		resolve(responseText);
 	}
 
-	async fetch(request: RequestDetails, tabId = Shared.tabId): Promise<AxiosResponse<string>> {
+	async fetch(request: RequestDetails, tabId = Shared.tabId): Promise<Response> {
 		const options = await this.getOptions(request, tabId);
+
 		const cancelKey = `${tabId !== null ? `${tabId}_` : ''}${request.cancelKey || 'default'}`;
 		if (!RequestsManager.abortControllers.has(cancelKey)) {
 			RequestsManager.abortControllers.set(cancelKey, new AbortController());
 		}
-		const signal = RequestsManager.abortControllers.get(cancelKey)?.signal;
+		request.signal = RequestsManager.abortControllers.get(cancelKey)?.signal;
 
-		const rateLimit = request.rateLimit ?? this.getRateLimit(request);
-		let instance = RequestsManager.instances.get(rateLimit.id);
-		if (!instance) {
-			instance = axiosRateLimit(axios.create(), { maxRPS: rateLimit.maxRPS });
-			RequestsManager.instances.set(rateLimit.id, instance);
-		}
-
-		return instance.request({
-			url: request.url,
-			method: options.method as Method,
+		return fetch(request.url, {
+			method: options.method,
 			headers: options.headers,
-			data: options.body,
-			responseType: 'text',
-			signal,
-			transformResponse: (res: string) => res,
-
-			// @ts-expect-error Custom prop
-			priority: request.priority || RequestPriority.NORMAL,
+			body: options.body,
+			signal: request.signal,
 		});
 	}
 
@@ -175,41 +146,6 @@ class _Requests {
 		});
 		return cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ');
 	}
-
-	getRateLimit(request: RequestDetails) {
-		let id;
-		let maxRPS;
-
-		if (request.withRateLimit) {
-			id = request.withRateLimit.id;
-			maxRPS = request.withRateLimit.maxRPS[request.method];
-
-			if (maxRPS) {
-				return {
-					id: `${id}_${request.method}`,
-					maxRPS,
-				};
-			}
-
-			maxRPS = request.withRateLimit.maxRPS['*'];
-
-			return { id, maxRPS };
-		}
-
-		id = this.withRateLimit.id;
-		maxRPS = this.withRateLimit.maxRPS[request.method];
-
-		if (maxRPS) {
-			return {
-				id: `${id}_${request.method}`,
-				maxRPS,
-			};
-		}
-
-		maxRPS = this.withRateLimit.maxRPS['*'];
-
-		return { id, maxRPS };
-	}
 }
 
 export const Requests = new _Requests();
@@ -222,20 +158,6 @@ export const withHeaders = (headers: Record<string, string>, instance = Requests
 		get: (target, prop, receiver) => {
 			if (prop === 'withHeaders') {
 				return { ...instance.withHeaders, ...headers };
-			}
-			return Reflect.get(target, prop, receiver) as unknown;
-		},
-	});
-};
-
-/**
- * Creates a proxy to a requests instance that uses the provided rate limit. Useful for making requests without having to provide the rate limit every time.
- */
-export const withRateLimit = (rateLimit: RateLimitConfig, instance = Requests) => {
-	return new Proxy(instance, {
-		get: (target, prop, receiver) => {
-			if (prop === 'withRateLimit') {
-				return { ...instance.withRateLimit, ...rateLimit };
 			}
 			return Reflect.get(target, prop, receiver) as unknown;
 		},

--- a/src/common/RequestsManager.ts
+++ b/src/common/RequestsManager.ts
@@ -1,12 +1,10 @@
 import { RequestsCancelData, StorageOptionsChangeData } from '@common/Events';
 import { Shared } from '@common/Shared';
 import { getServices } from '@models/Service';
-import { AxiosInstance } from 'axios';
 import browser, { WebRequest as WebExtWebRequest } from 'webextension-polyfill';
 
 class _RequestsManager {
 	abortControllers = new Map<string, AbortController>();
-	instances = new Map<string, AxiosInstance>();
 
 	init() {
 		if (Shared.pageType === 'background') {

--- a/src/common/ScriptInjector.ts
+++ b/src/common/ScriptInjector.ts
@@ -61,7 +61,6 @@ class _ScriptInjector {
 					hostPattern.replace(/^\*:\/\/\*\./, 'https?:\\/\\/([^/]*\\.)?').replace(/\/\*$/, '')
 				),
 				js: [`${service.id}.js`],
-				run_at: 'document_idle',
 			}));
 	}
 
@@ -93,15 +92,19 @@ class _ScriptInjector {
 		) {
 			return;
 		}
-		for (const { matches, js, run_at: runAt } of this.contentScripts) {
-			if (!js || !runAt) {
+		for (const { matches, js } of this.contentScripts) {
+			if (!js) {
 				continue;
 			}
 			const isMatch = matches.find((match) => tab.url?.match(match));
 			if (isMatch) {
 				this.injectedContentScriptTabs.add(tab.id);
 				for (const file of js) {
-					await browser.tabs.executeScript(tab.id, { file, runAt });
+					if (Shared.manifestVersion === 3) {
+						await browser.scripting.executeScript({ target: { tabId: tab.id }, files: [file] });
+					} else {
+						await browser.tabs.executeScript(tab.id, { file });
+					}
 				}
 				break;
 			}

--- a/src/common/ScrobbleParser.ts
+++ b/src/common/ScrobbleParser.ts
@@ -1,5 +1,6 @@
 import { ServiceApi } from '@apis/ServiceApi';
 import { ScriptInjector } from '@common/ScriptInjector';
+import { Shared } from '@common/Shared';
 import { createScrobbleItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
 
 export interface ScrobbleParserOptions {
@@ -82,7 +83,7 @@ export abstract class ScrobbleParser {
 	 * Below are the methods that can be used to parse the playback. Generic methods do not need to be overridden in the child class, as they should work out-of-the-box. If one method fails, the next one is attempted, in the order listed.
 	 *
 	 *   1. **video player:** generic method, based on `videoPlayerSelector`, which can be specified through the options
-	 *   2. **injected script:** specific method (requires implementation of `playbackFnToInject`)
+	 *   2. **injected script:** specific method (requires adding a function to the `{serviceId}-playback` key in `Shared.functionsToInject` at the `{serviceName}Api.ts` file e.g. `netflix-playback` at `NetflixApi.ts`)
 	 *   3. **DOM:** specific method (requires override)
 	 *   4. **custom:** specific method (requires override)
 	 */
@@ -169,19 +170,16 @@ export abstract class ScrobbleParser {
 	}
 
 	protected async parsePlaybackFromInjectedScript(): Promise<Partial<ScrobblePlayback> | null> {
-		if (this.playbackFnToInject) {
+		if (`${this.api.id}-playback` in Shared.functionsToInject) {
 			const playback = await ScriptInjector.inject<Partial<ScrobblePlayback>>(
 				this.api.id,
 				'playback',
-				'',
-				this.playbackFnToInject
+				''
 			);
 			return playback;
 		}
 		return null;
 	}
-
-	protected playbackFnToInject: (() => Partial<ScrobblePlayback> | null) | null = null;
 
 	protected parsePlaybackFromDom(): Promisable<Partial<ScrobblePlayback> | null> {
 		return null;
@@ -195,7 +193,7 @@ export abstract class ScrobbleParser {
 	 * Below are the methods that can be used to parse the item. Generic methods do not need to be overridden in the child class, as they should work out-of-the-box. If one method fails, the next one is attempted, in the order listed.
 	 *
 	 *   1. **API:** generic method, but requires a non-null return from `parseItemId` and the implementation of `*Api#getItem`
-	 *   2. **injected script:** specific method (requires implementation of `itemFnToInject`)
+	 *   2. **injected script:** specific method (requires adding a function to the `{serviceId}-item` key in `Shared.functionsToInject` at the `{serviceName}Api.ts` file e.g. `netflix-item` at `NetflixApi.ts`)
 	 *   3. **DOM:** specific method (requires override)
 	 *   4. **custom:** specific method (requires override)
 	 */
@@ -235,21 +233,14 @@ export abstract class ScrobbleParser {
 	}
 
 	protected async parseItemFromInjectedScript(): Promise<ScrobbleItem | null> {
-		if (this.itemFnToInject) {
-			const savedItem = await ScriptInjector.inject<ScrobbleItemValues>(
-				this.api.id,
-				'item',
-				'',
-				this.itemFnToInject
-			);
+		if (`${this.api.id}-item` in Shared.functionsToInject) {
+			const savedItem = await ScriptInjector.inject<ScrobbleItemValues>(this.api.id, 'item', '');
 			if (savedItem) {
 				return createScrobbleItem(savedItem);
 			}
 		}
 		return null;
 	}
-
-	protected itemFnToInject: (() => ScrobbleItemValues | null) | null = null;
 
 	protected parseItemFromDom(): Promisable<ScrobbleItem | null> {
 		return null;
@@ -263,7 +254,7 @@ export abstract class ScrobbleParser {
 	 * Below are the methods that can be used to parse the item ID. Generic methods do not need to be overridden in the child class, as they should work out-of-the-box. If one method fails, the next one is attempted, in the order listed.
 	 *
 	 *   1. **URL:** generic method, based on `watchingUrlRegex`, which can be specified through the options
-	 *   2. **injected script:** specific method (requires implementation of `itemIdFnToInject`)
+	 *   2. **injected script:** specific method (requires adding a function to the `{serviceId}-item-id` key in `Shared.functionsToInject` at the `{serviceName}Api.ts` file e.g. `netflix-item-id` at `NetflixApi.ts`)
 	 *   3. **DOM:** specific method (requires override)
 	 *   4. **custom:** specific method (requires override)
 	 */
@@ -301,19 +292,12 @@ export abstract class ScrobbleParser {
 	}
 
 	protected async parseItemIdFromInjectedScript(): Promise<string | null> {
-		if (this.itemIdFnToInject) {
-			const id = await ScriptInjector.inject<string>(
-				this.api.id,
-				'item-id',
-				'',
-				this.itemIdFnToInject
-			);
+		if (`${this.api.id}-item-id` in Shared.functionsToInject) {
+			const id = await ScriptInjector.inject<string>(this.api.id, 'item-id', '');
 			return id;
 		}
 		return null;
 	}
-
-	protected itemIdFnToInject: (() => string | null) | null = null;
 
 	protected parseItemIdFromDom(): Promisable<string | null> {
 		return null;

--- a/src/common/SessionStorage.ts
+++ b/src/common/SessionStorage.ts
@@ -1,0 +1,26 @@
+import browser, { Storage as WebExtStorage } from 'webextension-polyfill';
+import { Shared } from '@common/Shared';
+
+export interface SessionStorageValues {
+	injectedContentScriptTabs?: number[];
+}
+
+class _SessionStorage {
+	instance =
+		Shared.manifestVersion === 3
+			? // @ts-expect-error `session` is a newer key, so it's missing from the types.
+			  (browser.storage.session as WebExtStorage.LocalStorageArea)
+			: browser.storage.local;
+
+	async set(values: SessionStorageValues): Promise<void> {
+		return this.instance.set(values);
+	}
+
+	async get(
+		keys?: keyof SessionStorageValues | (keyof SessionStorageValues)[] | null
+	): Promise<SessionStorageValues> {
+		return this.instance.get(keys);
+	}
+}
+
+export const SessionStorage = new _SessionStorage();

--- a/src/common/Shared.ts
+++ b/src/common/Shared.ts
@@ -12,6 +12,7 @@ export interface SharedValues {
 	rollbarToken: string;
 	tmdbApiKey: string;
 
+	manifestVersion: number;
 	browser: BrowserName;
 	pageType: PageType;
 	tabId: number | null;
@@ -56,6 +57,7 @@ export const Shared: SharedValues = {
 	rollbarToken: process.env.ROLLBAR_TOKEN || '',
 	tmdbApiKey: process.env.TMDB_API_KEY || '',
 
+	manifestVersion: browser.runtime.getManifest().manifest_version,
 	browser: browsers[browserPrefix] || 'unknown',
 	pageType: 'content',
 	tabId: null,

--- a/src/common/Shared.ts
+++ b/src/common/Shared.ts
@@ -23,6 +23,8 @@ export interface SharedValues {
 	errors: typeof Errors;
 	events: typeof EventDispatcher;
 
+	functionsToInject: Record<string, () => unknown>;
+
 	waitForInit: () => Promise<unknown>;
 	finishInit: () => void;
 }
@@ -66,6 +68,8 @@ export const Shared: SharedValues = {
 	storage: {} as typeof BrowserStorage,
 	errors: {} as typeof Errors,
 	events: {} as typeof EventDispatcher,
+
+	functionsToInject: {},
 
 	waitForInit: () => initPromise,
 	finishInit: () => initPromiseResolve(null),

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -10,6 +10,8 @@ declare let cloneInto: <T>(value: T, window: Window) => T;
 
 declare type PromiseResolve<T> = (value: T | PromiseLike<T>) => void;
 
+declare type PromiseReject = (value: Error) => void;
+
 declare type Messages = typeof import('@locales/en/messages.json');
 
 declare type MessageName = keyof Messages;

--- a/src/modules/background/background.ts
+++ b/src/modules/background/background.ts
@@ -65,6 +65,9 @@ Messaging.addHandlers({
 	'show-notification': (message) => Notifications.show(message.title, message.message),
 
 	'send-to-all-content': (message) => Messaging.toAllContent(message.message),
+
+	'inject-function-from-background': ({ serviceId, key, url, params, tabId }) =>
+		ScriptInjector.injectInTab(serviceId, key, url, params, tabId),
 });
 
 void init();

--- a/src/modules/background/background.ts
+++ b/src/modules/background/background.ts
@@ -19,11 +19,13 @@ import '@images/uts-icon-38.png';
 import '@images/uts-icon-selected-19.png';
 import '@images/uts-icon-selected-38.png';
 
+Shared.pageType = 'background';
+
 Cache.addBackgroundListeners();
 AutoSync.addBackgroundListeners();
+Messaging.addListeners();
 
 const init = async () => {
-	Shared.pageType = 'background';
 	await BrowserStorage.init();
 	BrowserAction.init();
 	Errors.init();
@@ -38,6 +40,8 @@ const init = async () => {
 };
 
 Messaging.addHandlers({
+	'connect-content-script': (message, tabId) => Messaging.connectContentScript(message, tabId),
+
 	'open-tab': (message) => Tabs.open(message.url, message.extraProperties),
 
 	'get-tab-id': (message, tabId) => tabId,

--- a/src/modules/content/service/service.ts
+++ b/src/modules/content/service/service.ts
@@ -21,6 +21,6 @@ export const init = async (serviceId: string): Promise<void> => {
 };
 
 Messaging.addHandlers({
-	'inject-function': ({ serviceId, key, url, fnStr, fnParamsStr }) =>
-		ScriptInjector.inject(serviceId, key, url, fnStr, fnParamsStr),
+	'inject-function': ({ serviceId, key, url, params }) =>
+		ScriptInjector.inject(serviceId, key, url, params),
 });

--- a/src/modules/content/service/service.ts
+++ b/src/modules/content/service/service.ts
@@ -8,8 +8,11 @@ import { getScrobbleController } from '@common/ScrobbleController';
 import { getScrobbleEvents } from '@common/ScrobbleEvents';
 import { Shared } from '@common/Shared';
 
+Shared.pageType = 'content';
+
+Messaging.addListeners();
+
 export const init = async (serviceId: string): Promise<void> => {
-	Shared.pageType = 'content';
 	await BrowserStorage.init();
 	Errors.init();
 	EventDispatcher.init();

--- a/src/modules/history/history.tsx
+++ b/src/modules/history/history.tsx
@@ -9,8 +9,11 @@ import { HistoryApp } from '@history/HistoryApp';
 import { GlobalStyles } from '@mui/material';
 import ReactDOM from 'react-dom';
 
+Shared.pageType = 'popup';
+
+Messaging.addListeners();
+
 const init = async () => {
-	Shared.pageType = 'popup';
 	await BrowserStorage.init();
 	Errors.init();
 	EventDispatcher.init();

--- a/src/modules/options/options.tsx
+++ b/src/modules/options/options.tsx
@@ -7,8 +7,11 @@ import { AppWrapper } from '@components/AppWrapper';
 import { OptionsApp } from '@options/OptionsApp';
 import ReactDOM from 'react-dom';
 
+Shared.pageType = 'popup';
+
+Messaging.addListeners();
+
 const init = async () => {
-	Shared.pageType = 'popup';
 	await BrowserStorage.init();
 	Errors.init();
 	EventDispatcher.init();

--- a/src/modules/popup/components/PopupWatching.tsx
+++ b/src/modules/popup/components/PopupWatching.tsx
@@ -25,7 +25,7 @@ export const PopupWatching = ({ item, isPaused }: PopupWatchingProps): JSX.Eleme
 	return (
 		<>
 			<Box>
-				<BackgroundImage imageUrl={item.imageUrl} />
+				<BackgroundImage imageUrl={item.trakt?.imageUrl || item.imageUrl} />
 				<Box
 					sx={{
 						position: 'relative',

--- a/src/modules/popup/popup.tsx
+++ b/src/modules/popup/popup.tsx
@@ -8,8 +8,11 @@ import { AppWrapper } from '@components/AppWrapper';
 import { PopupApp } from '@popup/PopupApp';
 import ReactDOM from 'react-dom';
 
+Shared.pageType = 'popup';
+
+Messaging.addListeners();
+
 const init = async () => {
-	Shared.pageType = 'popup';
 	await BrowserStorage.init();
 	Errors.init();
 	EventDispatcher.init();

--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -223,7 +223,7 @@ class _AmazonPrimeApi extends ServiceApi {
 		return !!this.session && !!this.session.profileName;
 	}
 
-	async loadHistoryItems() {
+	async loadHistoryItems(cancelKey = 'default') {
 		if (!this.isActivated) {
 			await this.activate();
 		}
@@ -235,6 +235,7 @@ class _AmazonPrimeApi extends ServiceApi {
 				args: this.nextToken ? `%22nextToken%22%3A%22${this.nextToken}%22` : '',
 			}),
 			method: 'GET',
+			cancelKey,
 		});
 		const historyResponse = JSON.parse(historyResponseText) as AmazonPrimeHistoryResponse;
 

--- a/src/services/amc-plus/AmcPlusApi.ts
+++ b/src/services/amc-plus/AmcPlusApi.ts
@@ -163,24 +163,25 @@ class _AmcPlusApi extends ServiceApi {
 		const result = await ScriptInjector.inject<Partial<AmcPlusSession>>(
 			this.id,
 			'session',
-			this.HOST_URL,
-			() => {
-				const session: Partial<AmcPlusSession> = {};
-
-				const accessToken = window.localStorage.getItem('access_token') ?? '';
-				const cacheHash = window.localStorage.getItem('cache_hash') ?? '';
-				const userCacheHash = window.localStorage.getItem('user_cache_hash') ?? '';
-				session.auth = {
-					accessToken,
-					cacheHash,
-					userCacheHash,
-				};
-
-				return session;
-			}
+			this.HOST_URL
 		);
 		return result;
 	}
 }
+
+Shared.functionsToInject[`${AmcPlusService.id}-session`] = () => {
+	const session: Partial<AmcPlusSession> = {};
+
+	const accessToken = window.localStorage.getItem('access_token') ?? '';
+	const cacheHash = window.localStorage.getItem('cache_hash') ?? '';
+	const userCacheHash = window.localStorage.getItem('user_cache_hash') ?? '';
+	session.auth = {
+		accessToken,
+		cacheHash,
+		userCacheHash,
+	};
+
+	return session;
+};
 
 export const AmcPlusApi = new _AmcPlusApi();

--- a/src/services/crunchyroll/CrunchyrollApi.ts
+++ b/src/services/crunchyroll/CrunchyrollApi.ts
@@ -107,7 +107,7 @@ class _CrunchyrollApi extends ServiceApi {
 		return !!this.session && this.session.profileName !== null;
 	}
 
-	async loadHistoryItems(): Promise<CrunchyrollHistoryItem[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<CrunchyrollHistoryItem[]> {
 		// We do this here because the token will expire within minutes.
 		await this.checkLogin();
 
@@ -119,6 +119,7 @@ class _CrunchyrollApi extends ServiceApi {
 		const responseText = await this.authRequests.send({
 			url: this.nextHistoryUrl,
 			method: 'GET',
+			cancelKey,
 		});
 		const page = this.parseJsonWithDates<CrunchyrollHistoryPage>(responseText, [
 			'date_played',

--- a/src/services/hbo-max/HboMaxApi.ts
+++ b/src/services/hbo-max/HboMaxApi.ts
@@ -293,7 +293,7 @@ class _HboMaxApi extends ServiceApi {
 		return !!this.session && !!this.session.profileName;
 	}
 
-	async loadHistoryItems(): Promise<HboMaxHistoryItem[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<HboMaxHistoryItem[]> {
 		if (!this.isActivated) {
 			await this.activate();
 		}
@@ -306,6 +306,7 @@ class _HboMaxApi extends ServiceApi {
 		const historyResponseText = await this.authRequests.send({
 			url: Utils.replace(this.HISTORY_URL, this.session),
 			method: 'GET',
+			cancelKey,
 		});
 		const historyResponse = JSON.parse(historyResponseText) as HboMaxHistoryResponse;
 		const historyResponseItems = historyResponse.filter(

--- a/src/services/hbo-max/HboMaxApi.ts
+++ b/src/services/hbo-max/HboMaxApi.ts
@@ -432,27 +432,7 @@ class _HboMaxApi extends ServiceApi {
 		const result = await ScriptInjector.inject<Partial<HboMaxSession>>(
 			this.id,
 			'session',
-			this.HOST_URL,
-			() => {
-				const session: Partial<HboMaxSession> = {};
-
-				const authStr = window.localStorage.getItem('authToken');
-				if (authStr) {
-					const authObj = JSON.parse(authStr) as HboMaxAuthObj;
-					session.auth = {
-						accessToken: authObj.access_token,
-						refreshToken: authObj.refresh_token,
-						expiresAt: authObj.expires_on,
-					};
-				}
-
-				const deviceSerialNumber = window.localStorage.getItem('deviceSerialNumber');
-				if (deviceSerialNumber) {
-					session.deviceSerialNumber = deviceSerialNumber;
-				}
-
-				return session;
-			}
+			this.HOST_URL
 		);
 		if (result?.auth) {
 			result.auth.expiresAt = Utils.unix(result.auth.expiresAt);
@@ -460,5 +440,26 @@ class _HboMaxApi extends ServiceApi {
 		return result;
 	}
 }
+
+Shared.functionsToInject[`${HboMaxService.id}-session`] = () => {
+	const session: Partial<HboMaxSession> = {};
+
+	const authStr = window.localStorage.getItem('authToken');
+	if (authStr) {
+		const authObj = JSON.parse(authStr) as HboMaxAuthObj;
+		session.auth = {
+			accessToken: authObj.access_token,
+			refreshToken: authObj.refresh_token,
+			expiresAt: authObj.expires_on,
+		};
+	}
+
+	const deviceSerialNumber = window.localStorage.getItem('deviceSerialNumber');
+	if (deviceSerialNumber) {
+		session.deviceSerialNumber = deviceSerialNumber;
+	}
+
+	return session;
+};
 
 export const HboMaxApi = new _HboMaxApi();

--- a/src/services/mubi/MubiApi.ts
+++ b/src/services/mubi/MubiApi.ts
@@ -76,7 +76,7 @@ class _MubiApi extends ServiceApi {
 		return !!this.session;
 	}
 
-	async loadHistoryItems(): Promise<MubiHistoryItem[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<MubiHistoryItem[]> {
 		if (!this.session) {
 			await this.activate();
 		}
@@ -87,6 +87,7 @@ class _MubiApi extends ServiceApi {
 		const responseText = await this.sendRequest({
 			url: `${this.API_URL}/view_logs?page=${this.nextHistoryPage + 1}`,
 			method: 'GET',
+			cancelKey,
 		});
 		const responseJson = JSON.parse(responseText) as MubiHistoryResponse;
 		historyItems = responseJson?.view_logs ?? [];

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -445,19 +445,7 @@ class _NetflixApi extends ServiceApi {
 	}
 
 	getSession(): Promise<NetflixSession | null> {
-		return ScriptInjector.inject<NetflixSession>(this.id, 'session', '', () => {
-			let session: NetflixSession | null = null;
-			const { netflix } = window;
-			if (netflix) {
-				const { userInfo } = netflix.reactContext.models;
-				const authUrl = userInfo.data.authURL;
-				const profileName = userInfo.data.name;
-				if (authUrl) {
-					session = { authUrl, profileName };
-				}
-			}
-			return session;
-		});
+		return ScriptInjector.inject<NetflixSession>(this.id, 'session', '');
 	}
 
 	extractSession(text: string): NetflixSession | null {
@@ -472,5 +460,19 @@ class _NetflixApi extends ServiceApi {
 		return session;
 	}
 }
+
+Shared.functionsToInject[`${NetflixService.id}-session`] = () => {
+	let session: NetflixSession | null = null;
+	const { netflix } = window;
+	if (netflix) {
+		const { userInfo } = netflix.reactContext.models;
+		const authUrl = userInfo.data.authURL;
+		const profileName = userInfo.data.name;
+		if (authUrl) {
+			session = { authUrl, profileName };
+		}
+	}
+	return session;
+};
 
 export const NetflixApi = new _NetflixApi();

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -206,7 +206,7 @@ class _NetflixApi extends ServiceApi {
 		return this.session?.profileName != null;
 	}
 
-	async loadHistoryItems(): Promise<NetflixHistoryItem[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<NetflixHistoryItem[]> {
 		if (!this.isActivated) {
 			await this.activate();
 		}
@@ -216,6 +216,7 @@ class _NetflixApi extends ServiceApi {
 		const responseText = await Requests.send({
 			url: `${this.API_URL}/mre/viewingactivity?languages=en-US&authURL=${this.session.authUrl}&pg=${this.nextHistoryPage}`,
 			method: 'GET',
+			cancelKey,
 		});
 		const responseJson = JSON.parse(responseText) as NetflixHistoryResponse;
 		const responseItems = responseJson?.viewedItems ?? [];

--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -1,6 +1,7 @@
 import { NrkService } from '@/nrk/NrkService';
 import { ServiceApi } from '@apis/ServiceApi';
 import { Requests, withHeaders } from '@common/Requests';
+import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
 import {
 	BaseItemValues,
@@ -333,5 +334,17 @@ class _NrkApi extends ServiceApi {
 		});
 	}
 }
+
+Shared.functionsToInject[`${NrkService.id}-item-id`] = () => {
+	let itemId: string | null = null;
+	const { player } = window;
+	if (player) {
+		const playbackSession = player.getPlaybackSession();
+		if (playbackSession) {
+			itemId = playbackSession.mediaItem?.id ?? null;
+		}
+	}
+	return itemId;
+};
 
 export const NrkApi = new _NrkApi();

--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -179,13 +179,14 @@ class _NrkApi extends ServiceApi {
 		return !!this.session && this.session.profileName !== null;
 	}
 
-	async loadHistoryItems(): Promise<NrkProgressItem[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<NrkProgressItem[]> {
 		if (!this.isActivated) {
 			await this.activate();
 		}
 		const responseText = await this.authRequests.send({
 			url: this.nextHistoryUrl,
 			method: 'GET',
+			cancelKey,
 		});
 		const responseJson = JSON.parse(responseText) as NrkProgressResponse;
 		const responseItems = responseJson.progresses;

--- a/src/services/nrk/NrkParser.ts
+++ b/src/services/nrk/NrkParser.ts
@@ -5,17 +5,6 @@ class _NrkParser extends ScrobbleParser {
 	constructor() {
 		super(NrkApi, { videoPlayerSelector: '.tv-series-video-player video' });
 	}
-
-	itemIdFnToInject = () => {
-		let itemId: string | null = null;
-		const { player } = window;
-		if (player) {
-			const playbackSession = player.getPlaybackSession();
-			if (playbackSession) {
-				itemId = playbackSession.mediaItem?.id ?? null;
-			}
-		}
-		return itemId;
-	};
 }
+
 export const NrkParser = new _NrkParser();

--- a/src/services/viaplay/ViaplayApi.ts
+++ b/src/services/viaplay/ViaplayApi.ts
@@ -153,13 +153,14 @@ class _ViaplayApi extends ServiceApi {
 		return !!this.session && this.session.profileName !== null;
 	}
 
-	async loadHistoryItems(): Promise<ViaplayProduct[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<ViaplayProduct[]> {
 		if (!this.isActivated) {
 			await this.activate();
 		}
 		const responseText = await Requests.send({
 			url: this.nextHistoryUrl,
 			method: 'GET',
+			cancelKey,
 		});
 		let historyPage: ViaplayHistoryPage;
 		if (this.nextHistoryUrl === this.HISTORY_API_URL) {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -235,17 +235,6 @@ const getManifest = (browserName: string): string => {
 			},
 		],
 		default_locale: 'en',
-		optional_permissions: [
-			'cookies',
-			'notifications',
-			'tabs',
-			'webRequest',
-			'webRequestBlocking',
-			'*://api.rollbar.com/*',
-			...Object.values(services)
-				.map((service) => service.hostPatterns)
-				.flat(),
-		],
 		browser_action: {
 			default_icon: {
 				19: 'images/uts-icon-19.png',
@@ -254,15 +243,6 @@ const getManifest = (browserName: string): string => {
 			default_popup: 'popup.html',
 			default_title: 'Universal Trakt Scrobbler',
 		},
-		permissions: [
-			'alarms',
-			'identity',
-			'storage',
-			'unlimitedStorage',
-			'*://*.trakt.tv/*',
-			'*://*.themoviedb.org/*',
-			'*://*.uts.rafaelgomes.xyz/*',
-		],
 		web_accessible_resources: ['images/*'],
 		// Uncomment this to connect to react-devtools
 		// content_security_policy: "script-src 'self' http://localhost:8097; object-src 'self'",
@@ -273,6 +253,20 @@ const getManifest = (browserName: string): string => {
 			manifest.background = {
 				service_worker: 'background.js',
 			};
+			manifest.optional_permissions = ['notifications', 'tabs'];
+			// @ts-expect-error This is a newer key, so it's missing from the types.
+			manifest.optional_host_permissions = [
+				'*://api.rollbar.com/*',
+				...Object.values(services)
+					.map((service) => service.hostPatterns)
+					.flat(),
+			];
+			manifest.permissions = ['alarms', 'identity', 'storage', 'unlimitedStorage'];
+			manifest.host_permissions = [
+				'*://*.trakt.tv/*',
+				'*://*.themoviedb.org/*',
+				'*://*.uts.rafaelgomes.xyz/*',
+			];
 			if (process.env.CHROME_EXTENSION_KEY) {
 				manifest.key = process.env.CHROME_EXTENSION_KEY;
 			}
@@ -284,6 +278,26 @@ const getManifest = (browserName: string): string => {
 				scripts: ['background.js'],
 				persistent: false,
 			};
+			manifest.optional_permissions = [
+				'cookies',
+				'notifications',
+				'tabs',
+				'webRequest',
+				'webRequestBlocking',
+				'*://api.rollbar.com/*',
+				...Object.values(services)
+					.map((service) => service.hostPatterns)
+					.flat(),
+			];
+			manifest.permissions = [
+				'alarms',
+				'identity',
+				'storage',
+				'unlimitedStorage',
+				'*://*.trakt.tv/*',
+				'*://*.themoviedb.org/*',
+				'*://*.uts.rafaelgomes.xyz/*',
+			];
 			if (process.env.FIREFOX_EXTENSION_ID) {
 				manifest.browser_specific_settings = {
 					gecko: {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -235,14 +235,6 @@ const getManifest = (browserName: string): string => {
 			},
 		],
 		default_locale: 'en',
-		browser_action: {
-			default_icon: {
-				19: 'images/uts-icon-19.png',
-				38: 'images/uts-icon-38.png',
-			},
-			default_popup: 'popup.html',
-			default_title: 'Universal Trakt Scrobbler',
-		},
 		web_accessible_resources: ['images/*'],
 	};
 	switch (browserName) {
@@ -265,6 +257,14 @@ const getManifest = (browserName: string): string => {
 				'*://*.themoviedb.org/*',
 				'*://*.uts.rafaelgomes.xyz/*',
 			];
+			manifest.action = {
+				default_icon: {
+					19: 'images/uts-icon-19.png',
+					38: 'images/uts-icon-38.png',
+				},
+				default_popup: 'popup.html',
+				default_title: 'Universal Trakt Scrobbler',
+			};
 			if (process.env.CHROME_EXTENSION_KEY) {
 				manifest.key = process.env.CHROME_EXTENSION_KEY;
 			}
@@ -296,6 +296,14 @@ const getManifest = (browserName: string): string => {
 				'*://*.themoviedb.org/*',
 				'*://*.uts.rafaelgomes.xyz/*',
 			];
+			manifest.browser_action = {
+				default_icon: {
+					19: 'images/uts-icon-19.png',
+					38: 'images/uts-icon-38.png',
+				},
+				default_popup: 'popup.html',
+				default_title: 'Universal Trakt Scrobbler',
+			};
 			// Uncomment this to connect to react-devtools
 			// manifest.content_security_policy =
 			// 	"script-src 'self' http://localhost:8097; object-src 'self'";

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -219,8 +219,7 @@ const getWebpackConfig = (env: Environment): webpack.Configuration => {
 };
 
 const getManifest = (browserName: string): string => {
-	const manifest: WebExtManifest.WebExtensionManifest & { key?: string } = {
-		manifest_version: 2,
+	const manifest: Partial<WebExtManifest.WebExtensionManifest> & { key?: string } = {
 		name: 'Universal Trakt Scrobbler',
 		version: packageJson.version,
 		description: '__MSG_appDescription__',
@@ -274,12 +273,14 @@ const getManifest = (browserName: string): string => {
 	};
 	switch (browserName) {
 		case 'chrome': {
+			manifest.manifest_version = 3;
 			if (process.env.CHROME_EXTENSION_KEY) {
 				manifest.key = process.env.CHROME_EXTENSION_KEY;
 			}
 			break;
 		}
 		case 'firefox': {
+			manifest.manifest_version = 2;
 			if (process.env.FIREFOX_EXTENSION_ID) {
 				manifest.browser_specific_settings = {
 					gecko: {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -244,8 +244,6 @@ const getManifest = (browserName: string): string => {
 			default_title: 'Universal Trakt Scrobbler',
 		},
 		web_accessible_resources: ['images/*'],
-		// Uncomment this to connect to react-devtools
-		// content_security_policy: "script-src 'self' http://localhost:8097; object-src 'self'",
 	};
 	switch (browserName) {
 		case 'chrome': {
@@ -298,6 +296,9 @@ const getManifest = (browserName: string): string => {
 				'*://*.themoviedb.org/*',
 				'*://*.uts.rafaelgomes.xyz/*',
 			];
+			// Uncomment this to connect to react-devtools
+			// manifest.content_security_policy =
+			// 	"script-src 'self' http://localhost:8097; object-src 'self'";
 			if (process.env.FIREFOX_EXTENSION_ID) {
 				manifest.browser_specific_settings = {
 					gecko: {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -231,7 +231,6 @@ const getManifest = (browserName: string): string => {
 			{
 				js: ['trakt.js'],
 				matches: ['*://*.trakt.tv/apps*'],
-				run_at: 'document_start',
 			},
 		],
 		default_locale: 'en',
@@ -250,7 +249,7 @@ const getManifest = (browserName: string): string => {
 					.map((service) => service.hostPatterns)
 					.flat(),
 			];
-			manifest.permissions = ['alarms', 'identity', 'storage', 'unlimitedStorage'];
+			manifest.permissions = ['alarms', 'identity', 'scripting', 'storage', 'unlimitedStorage'];
 			manifest.host_permissions = [
 				'*://*.trakt.tv/*',
 				'*://*.themoviedb.org/*',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -227,10 +227,6 @@ const getManifest = (browserName: string): string => {
 			16: 'images/uts-icon-16.png',
 			128: 'images/uts-icon-128.png',
 		},
-		background: {
-			scripts: ['background.js'],
-			persistent: true,
-		},
 		content_scripts: [
 			{
 				js: ['trakt.js'],
@@ -274,6 +270,9 @@ const getManifest = (browserName: string): string => {
 	switch (browserName) {
 		case 'chrome': {
 			manifest.manifest_version = 3;
+			manifest.background = {
+				service_worker: 'background.js',
+			};
 			if (process.env.CHROME_EXTENSION_KEY) {
 				manifest.key = process.env.CHROME_EXTENSION_KEY;
 			}
@@ -281,6 +280,10 @@ const getManifest = (browserName: string): string => {
 		}
 		case 'firefox': {
 			manifest.manifest_version = 2;
+			manifest.background = {
+				scripts: ['background.js'],
+				persistent: false,
+			};
 			if (process.env.FIREFOX_EXTENSION_ID) {
 				manifest.browser_specific_settings = {
 					gecko: {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -235,7 +235,6 @@ const getManifest = (browserName: string): string => {
 			},
 		],
 		default_locale: 'en',
-		web_accessible_resources: ['images/*'],
 	};
 	switch (browserName) {
 		case 'chrome': {


### PR DESCRIPTION
Fixes #156

**NOTE:** This should be carefully tested, as some things might still be broken. I'll continue to test on my end throughout this week.

This follows Chrome's [migration guide](https://developer.chrome.com/docs/extensions/mv3/mv3-migration/) and:

- [x] changes manifest version to v3
- [x] changes background script to service worker
- [x] separates permissions from host permissions
- [x] removes content security policy
- [x] renames browser action to action
- [x] removes web accessible resources
- [x] uses scripting API to inject content scripts
- [x] uses scripting API to inject functions (all functions that need to be injected now have to be added to `Shared.functionsToInject` on first run, because they need to be accessible from the service worker)
- [x] removes ports, as they're not compatible with service workers (the new method to identify when a content script has connected is to send a message to the service worker, and the new method to identify when a content script has disconnected is to add a listener to `browser.tabs.onRemoved`)
- [x] removes axios, as `XMLHttpRequest` isn't compatible with service workers (rate limiting has been removed as well, but our requests are already sequential, so they shouldn't cause many issues)
- [x] removes window/document references from background logic, as they're not available in service workers

There might be other changes that need to be made.

These changes should be fully backwards compatible with manifest v2. Webpack is configured to build v2 for Firefox and v3 for Chrome, as v3 isn't accepted in the Firefox store yet, as far as I could tell.