### PR TITLE
Improves history view

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -316,6 +316,9 @@
 	"options": {
 		"message": "Options"
 	},
+	"otherPlays": {
+		"message": "Other plays:"
+	},
 	"profile": {
 		"message": "Profile"
 	},
@@ -451,6 +454,14 @@
 	},
 	"watched": {
 		"message": "Watched On"
+	},
+	"watchedOtherTimes": {
+		"message": "Watched $COUNT$ other times",
+		"placeholders": {
+			"count": {
+				"content": "$1"
+			}
+		}
 	},
 	"yes": {
 		"message": "Yes"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -216,6 +216,9 @@
 	"itemSynced": {
 		"message": "Item synced"
 	},
+	"itemSyncStatusUnknown": {
+		"message": "Item sync status unknown"
+	},
 	"itemsMissingWatchedDate": {
 		"message": "Some items are missing the watched date. Resolve each item or enable the option to add with release date and try again."
 	},

--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -204,7 +204,9 @@ export abstract class ServiceApi {
 						break;
 					}
 				}
-				hasReachedEnd = this.hasReachedHistoryEnd || hasReachedLastSyncDate;
+				hasReachedEnd =
+					(this.leftoverHistoryItems.length === 0 && this.hasReachedHistoryEnd) ||
+					hasReachedLastSyncDate;
 			} while (!hasReachedEnd && itemsToLoad > 0);
 			if (historyItems.length > 0) {
 				const tmpItems: (ScrobbleItem | null)[] = [];

--- a/src/apis/TmdbApi.ts
+++ b/src/apis/TmdbApi.ts
@@ -91,7 +91,7 @@ class _TmdbApi {
 		if (!this.config || !item?.tmdbId) {
 			return null;
 		}
-		const cache = await Cache.get('imageUrls');
+		const cache = await Cache.get('tmdbImageUrls');
 		const databaseId = item.getDatabaseId();
 		let imageUrl = cache.get(databaseId);
 		if (typeof imageUrl !== 'undefined') {
@@ -107,7 +107,7 @@ class _TmdbApi {
 			if (image?.file_path) {
 				imageUrl = `${this.config.baseUrl}${this.config.sizes[item.type]}${image.file_path}`;
 				cache.set(databaseId, imageUrl);
-				await Cache.set({ imageUrls: cache });
+				await Cache.set({ tmdbImageUrls: cache });
 				return imageUrl;
 			}
 		} catch (err) {
@@ -149,22 +149,22 @@ class _TmdbApi {
 	 * If all images have already been loaded, returns the same parameter array, otherwise returns a new array for immutability.
 	 */
 	async loadImages(items: ScrobbleItem[]): Promise<ScrobbleItem[]> {
-		const hasLoadedImages = !items.some((item) => typeof item.imageUrl === 'undefined');
+		const hasLoadedImages = !items.some((item) => typeof item.trakt?.imageUrl === 'undefined');
 		if (hasLoadedImages) {
 			return items;
 		}
 		const newItems = items.map((item) => item.clone());
-		const cache = await Cache.get('imageUrls');
+		const cache = await Cache.get('tmdbImageUrls');
 		try {
 			const itemsToFetch: ScrobbleItem[] = [];
 			for (const item of newItems) {
-				if (!item.trakt || typeof item.imageUrl !== 'undefined') {
+				if (!item.trakt || typeof item.trakt.imageUrl !== 'undefined') {
 					continue;
 				}
 				const databaseId = item.trakt.getDatabaseId();
 				const imageUrl = cache.get(databaseId);
 				if (typeof imageUrl !== 'undefined') {
-					item.imageUrl = imageUrl;
+					item.trakt.imageUrl = imageUrl;
 				} else {
 					itemsToFetch.push(item);
 				}
@@ -198,7 +198,7 @@ class _TmdbApi {
 						continue;
 					}
 					const databaseId = item.trakt.getDatabaseId();
-					item.imageUrl = json?.result[databaseId] || (await this.findImage(item.trakt));
+					item.trakt.imageUrl = json?.result[databaseId] || (await this.findImage(item.trakt));
 				}
 			}
 		} catch (err) {
@@ -210,10 +210,10 @@ class _TmdbApi {
 				continue;
 			}
 			const databaseId = item.trakt.getDatabaseId();
-			item.imageUrl = item.imageUrl || null;
-			cache.set(databaseId, item.imageUrl);
+			item.trakt.imageUrl = item.trakt.imageUrl || null;
+			cache.set(databaseId, item.trakt.imageUrl);
 		}
-		await Cache.set({ imageUrls: cache });
+		await Cache.set({ tmdbImageUrls: cache });
 		return newItems;
 	}
 }

--- a/src/apis/TraktSync.ts
+++ b/src/apis/TraktSync.ts
@@ -62,6 +62,7 @@ class _TraktSync extends TraktApi {
 			traktHistoryItemsCache.set(databaseId, historyItems);
 		}
 		let historyItemMatch: ParsedTraktHistoryItem | null = null;
+		const historyItemOtherWatches: number[] = [];
 		for (const historyItem of historyItems) {
 			const parsedHistoryItem: ParsedTraktHistoryItem = {
 				id: historyItem.id,
@@ -72,6 +73,8 @@ class _TraktSync extends TraktApi {
 				break;
 			} else if (Utils.dateDiff(watchedAt, parsedHistoryItem.watched_at, 26 * 60 * 60)) {
 				historyItemMatch = parsedHistoryItem;
+			} else {
+				historyItemOtherWatches.push(parsedHistoryItem.watched_at);
 			}
 		}
 		if (historyItemMatch) {
@@ -80,6 +83,8 @@ class _TraktSync extends TraktApi {
 		} else {
 			item.trakt.watchedAt = null;
 		}
+
+		item.trakt.otherWatches = historyItemOtherWatches;
 	}
 
 	async removeHistory(item: ScrobbleItem): Promise<void> {

--- a/src/common/Cache.ts
+++ b/src/common/Cache.ts
@@ -19,12 +19,12 @@ export type CacheValues = {
 export interface CacheSubValues {
 	history: HistoryCache;
 	historyItemsToItems: string;
-	imageUrls: string | null;
 	items: ScrobbleItemValues;
 	itemsToTraktItems: string;
 	servicesData: unknown;
 	suggestions: Suggestion[] | null;
 	tmdbApiConfigs: TmdbApiConfig | null;
+	tmdbImageUrls: string | null;
 	traktHistoryItems: TraktHistoryItem[];
 	traktItems: TraktItemValues;
 	traktSettings: TraktSettingsResponse;
@@ -79,12 +79,12 @@ class _Cache {
 	private ttl: Record<keyof CacheValues, number> = {
 		history: 24 * 60 * 60,
 		historyItemsToItems: 24 * 60 * 60,
-		imageUrls: 24 * 60 * 60,
 		items: 24 * 60 * 60,
 		itemsToTraktItems: 24 * 60 * 60,
 		servicesData: 24 * 60 * 60,
 		suggestions: 60 * 60,
 		tmdbApiConfigs: 7 * 24 * 60 * 60,
+		tmdbImageUrls: 24 * 60 * 60,
 		traktHistoryItems: 45 * 60,
 		traktItems: 24 * 60 * 60,
 		traktSettings: 24 * 60 * 60,

--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -2,17 +2,22 @@ import { FullView } from '@components/FullView';
 import TraktIconImage from '@images/trakt-icon.png';
 import { Box } from '@mui/material';
 
-interface TmdbImageProps {
+interface BackgroundImageProps {
 	imageUrl?: string | null;
+	/** Fallback image in case {@link imageUrl} is falsy. Defaults to the Trakt logo. */
+	fallbackImageUrl?: string;
 }
 
-export const TmdbImage = ({ imageUrl }: TmdbImageProps): JSX.Element => {
+export const BackgroundImage = ({
+	imageUrl,
+	fallbackImageUrl = TraktIconImage,
+}: BackgroundImageProps): JSX.Element => {
 	return (
 		<Box>
 			<FullView
 				sx={{
 					backgroundColor: '#000',
-					backgroundImage: `url("${imageUrl || TraktIconImage}")`,
+					backgroundImage: `url("${imageUrl || fallbackImageUrl}")`,
 					backgroundPosition: 'center',
 					backgroundSize: 'cover',
 					backgroundRepeat: 'no-repeat',

--- a/src/models/TraktItem.ts
+++ b/src/models/TraktItem.ts
@@ -17,6 +17,7 @@ export interface TraktBaseItemValues {
 	/** List of other watchedAt values available */
 	otherWatches?: number[];
 	progress?: number;
+	imageUrl?: string | null;
 }
 
 export interface TraktEpisodeItemValues extends TraktBaseItemValues {
@@ -52,6 +53,7 @@ abstract class TraktBaseItem implements TraktBaseItemValues {
 	watchedAt?: number | null;
 	otherWatches?: number[];
 	progress: number;
+	imageUrl?: string | null;
 
 	constructor(values: TraktBaseItemValues) {
 		this.id = values.id;
@@ -64,6 +66,7 @@ abstract class TraktBaseItem implements TraktBaseItemValues {
 		this.otherWatches =
 			values.otherWatches != null ? [...values.otherWatches] : values.otherWatches;
 		this.progress = values.progress ? Math.round(values.progress * 100) / 100 : 0.0;
+		this.imageUrl = values.imageUrl;
 	}
 
 	save(): TraktBaseItemValues {
@@ -77,6 +80,7 @@ abstract class TraktBaseItem implements TraktBaseItemValues {
 			watchedAt: this.watchedAt,
 			otherWatches: this.otherWatches != null ? [...this.otherWatches] : this.otherWatches,
 			progress: this.progress,
+			imageUrl: this.imageUrl,
 		};
 	}
 

--- a/src/models/TraktItem.ts
+++ b/src/models/TraktItem.ts
@@ -14,6 +14,8 @@ export interface TraktBaseItemValues {
 	year: number;
 	releaseDate?: number;
 	watchedAt?: number | null;
+	/** List of other watchedAt values available */
+	otherWatches?: number[];
 	progress?: number;
 }
 
@@ -48,6 +50,7 @@ abstract class TraktBaseItem implements TraktBaseItemValues {
 	year: number;
 	releaseDate?: number;
 	watchedAt?: number | null;
+	otherWatches?: number[];
 	progress: number;
 
 	constructor(values: TraktBaseItemValues) {
@@ -58,6 +61,8 @@ abstract class TraktBaseItem implements TraktBaseItemValues {
 		this.year = values.year;
 		this.releaseDate = values.releaseDate;
 		this.watchedAt = values.watchedAt;
+		this.otherWatches =
+			values.otherWatches != null ? [...values.otherWatches] : values.otherWatches;
 		this.progress = values.progress ? Math.round(values.progress * 100) / 100 : 0.0;
 	}
 
@@ -70,6 +75,7 @@ abstract class TraktBaseItem implements TraktBaseItemValues {
 			year: this.year,
 			releaseDate: this.releaseDate,
 			watchedAt: this.watchedAt,
+			otherWatches: this.otherWatches != null ? [...this.otherWatches] : this.otherWatches,
 			progress: this.progress,
 		};
 	}

--- a/src/modules/history/components/HistoryActions.tsx
+++ b/src/modules/history/components/HistoryActions.tsx
@@ -1,11 +1,13 @@
 import { I18N } from '@common/I18N';
 import { Shared } from '@common/Shared';
 import { useSync } from '@contexts/SyncContext';
-import { Box, Button, Divider } from '@mui/material';
+import { Box, Button, Divider, useTheme } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 export const HistoryActions = (): JSX.Element => {
 	const { serviceId, store } = useSync();
+
+	const theme = useTheme();
 
 	const [areItemsMissingWatchedDate, setItemsMissingWatchedDate] = useState(
 		store.areItemsMissingWatchedDate()
@@ -73,7 +75,7 @@ export const HistoryActions = (): JSX.Element => {
 		<Box
 			sx={{
 				zIndex: ({ zIndex }) => zIndex.drawer + 1,
-				backgroundColor: '#fff',
+				backgroundColor: theme.palette.background.default,
 			}}
 		>
 			<Divider />

--- a/src/modules/history/components/HistoryHeader.tsx
+++ b/src/modules/history/components/HistoryHeader.tsx
@@ -36,7 +36,6 @@ export const HistoryHeader = (): JSX.Element => {
 			position="sticky"
 			sx={{
 				zIndex: ({ zIndex }) => zIndex.drawer + 1,
-				color: '#fff',
 			}}
 		>
 			<Toolbar>

--- a/src/modules/history/components/HistoryListItem.tsx
+++ b/src/modules/history/components/HistoryListItem.tsx
@@ -153,6 +153,7 @@ const _HistoryListItem = ({
 						isLoading={item?.isLoading ?? true}
 						item={item}
 						name={serviceName}
+						imageUrl={item?.imageUrl}
 						openMissingWatchedDateDialog={openMissingWatchedDateDialog}
 					/>
 					<Tooltip title={I18N.translate(statusMessageName)}>
@@ -177,7 +178,7 @@ const _HistoryListItem = ({
 						item={item?.trakt}
 						name="Trakt"
 						suggestions={item?.suggestions}
-						imageUrl={item?.imageUrl}
+						imageUrl={item?.trakt?.imageUrl}
 						openCorrectionDialog={openCorrectionDialog}
 					/>
 				</>

--- a/src/modules/history/components/HistoryListItem.tsx
+++ b/src/modules/history/components/HistoryListItem.tsx
@@ -8,7 +8,7 @@ import { ScrobbleItem } from '@models/Item';
 import { getService } from '@models/Service';
 import { Sync as SyncIcon } from '@mui/icons-material';
 import { Box, Button, Checkbox, Tooltip, Typography } from '@mui/material';
-import { green, red } from '@mui/material/colors';
+import { green, grey, red } from '@mui/material/colors';
 import { ChangeEvent, memo, useEffect, useState } from 'react';
 import { areEqual, ListChildComponentProps } from 'react-window';
 

--- a/src/modules/history/components/HistoryListItem.tsx
+++ b/src/modules/history/components/HistoryListItem.tsx
@@ -81,9 +81,11 @@ const _HistoryListItem = ({
 		return stopListeners;
 	}, []);
 
-	const [statusColor, statusMessageName]: [string, MessageName] = item?.trakt?.watchedAt
-		? [green[500], 'itemSynced']
-		: [red[500], 'itemNotSynced'];
+	const [statusColor, statusMessageName]: [string, MessageName] = item?.trakt
+		? item?.trakt?.watchedAt
+			? [green[500], 'itemSynced']
+			: [red[500], 'itemNotSynced']
+		: [grey[700], 'itemSyncStatusUnknown'];
 	let serviceName;
 	if (item?.serviceId) {
 		serviceName = getService(item.serviceId).name;

--- a/src/modules/history/components/HistoryListItemCard.tsx
+++ b/src/modules/history/components/HistoryListItemCard.tsx
@@ -140,14 +140,28 @@ export const HistoryListItemCard = ({
 									>
 										{item.title}
 									</Typography>
-									<Typography variant="subtitle2">{item.show.title}</Typography>
+									<Typography
+										variant="subtitle2"
+										noWrap
+										style={{ overflow: 'hidden', textOverflow: 'ellipsis', width: '100%' }}
+										title={item.show.title}
+									>
+										{item.show.title}
+									</Typography>
 									<HistoryListItemDivider useDarkMode={hasImage} />
 									{watchedAtComponent}
 								</>
 							) : (
 								<>
 									{item.year && <Typography variant="overline">{item.year}</Typography>}
-									<Typography variant="h6">{item.title}</Typography>
+									<Typography
+										variant="h6"
+										noWrap
+										style={{ overflow: 'hidden', textOverflow: 'ellipsis', width: '100%' }}
+										title={item.title}
+									>
+										{item.title}
+									</Typography>
 									<HistoryListItemDivider useDarkMode={hasImage} />
 									{watchedAtComponent}
 								</>

--- a/src/modules/history/components/HistoryListItemCard.tsx
+++ b/src/modules/history/components/HistoryListItemCard.tsx
@@ -4,7 +4,7 @@ import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
 import { Center } from '@components/Center';
 import { HistoryListItemDivider } from '@components/HistoryListItemDivider';
-import { TmdbImage } from '@components/TmdbImage';
+import { BackgroundImage } from '@components/BackgroundImage';
 import { isItem, ScrobbleItem } from '@models/Item';
 import { isTraktItem, TraktItem } from '@models/TraktItem';
 import {
@@ -125,7 +125,8 @@ export const HistoryListItemCard = ({
 		);
 	}
 
-	const hasImage = isTraktItem(item) || item === null;
+	const hasImage: boolean =
+		Shared.storage.options.loadImages && (!!item?.imageUrl || isTraktItem(item) || item === null);
 	return (
 		<Card
 			variant="outlined"
@@ -142,7 +143,7 @@ export const HistoryListItemCard = ({
 					: {}),
 			}}
 		>
-			{hasImage && <TmdbImage imageUrl={imageUrl} />}
+			{hasImage && <BackgroundImage imageUrl={imageUrl} />}
 			<CardContent
 				sx={{
 					position: 'relative',

--- a/src/modules/history/components/HistoryListItemCard.tsx
+++ b/src/modules/history/components/HistoryListItemCard.tsx
@@ -79,6 +79,34 @@ export const HistoryListItemCard = ({
 					<Typography variant="caption">{I18N.translate('missingWatchedDate')}</Typography>
 				</Button>
 			);
+		} else if (isTraktItem(item) && item.otherWatches?.length) {
+			watchedAtComponent = (
+				<Typography variant="overline">
+					<Tooltip
+						title={
+							<span style={{ whiteSpace: 'pre-line', textAlign: 'center', display: 'block' }}>
+								{[
+									I18N.translate('otherPlays'),
+									...item.otherWatches.map((watch) => Utils.timestamp(watch)),
+								].join('\n')}
+							</span>
+						}
+					>
+						<Link
+							href={item.getHistoryUrl()}
+							target="_blank"
+							rel="noreferrer"
+							sx={{
+								color: 'inherit',
+								textDecorationColor: 'inherit',
+								textDecorationStyle: 'dotted',
+							}}
+						>
+							{I18N.translate('watchedOtherTimes', item.otherWatches.length.toString())}
+						</Link>
+					</Tooltip>
+				</Typography>
+			);
 		} else {
 			watchedAtComponent = (
 				<Typography variant="overline">{I18N.translate('notWatched')}</Typography>

--- a/src/modules/options/components/OptionsActions.tsx
+++ b/src/modules/options/components/OptionsActions.tsx
@@ -1,11 +1,13 @@
 import { Cache } from '@common/Cache';
 import { I18N } from '@common/I18N';
 import { Shared } from '@common/Shared';
-import { Box, Button, Divider } from '@mui/material';
+import { Box, Button, Divider, useTheme } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 export const OptionsActions = (): JSX.Element => {
 	const [cacheSize, setCacheSize] = useState('0 B');
+
+	const theme = useTheme();
 
 	const updateCachesSize = async () => {
 		setCacheSize(await Shared.storage.getSize(Cache.storageKeys));
@@ -73,7 +75,7 @@ export const OptionsActions = (): JSX.Element => {
 				right: 0,
 				bottom: 0,
 				left: 0,
-				backgroundColor: '#fff',
+				backgroundColor: theme.palette.background.default,
 			}}
 		>
 			<Divider />

--- a/src/modules/popup/components/PopupHeader.tsx
+++ b/src/modules/popup/components/PopupHeader.tsx
@@ -53,12 +53,7 @@ export const PopupHeader = (): JSX.Element => {
 	}, []);
 
 	return (
-		<AppBar
-			position="sticky"
-			sx={{
-				color: '#fff',
-			}}
-		>
+		<AppBar position="sticky">
 			<Toolbar>
 				<LeftRight
 					centerVertically={true}

--- a/src/modules/popup/components/PopupWatching.tsx
+++ b/src/modules/popup/components/PopupWatching.tsx
@@ -4,7 +4,7 @@ import { CorrectionDialog } from '@components/CorrectionDialog';
 import { CustomSnackbar } from '@components/CustomSnackbar';
 import { PopupInfo } from '@components/PopupInfo';
 import { PopupOverlay } from '@components/PopupOverlay';
-import { TmdbImage } from '@components/TmdbImage';
+import { BackgroundImage } from '@components/BackgroundImage';
 import { ScrobbleItem } from '@models/Item';
 import { Pause as PauseIcon } from '@mui/icons-material';
 import { Box, Button, LinearProgress, Tooltip, Typography } from '@mui/material';
@@ -25,7 +25,7 @@ export const PopupWatching = ({ item, isPaused }: PopupWatchingProps): JSX.Eleme
 	return (
 		<>
 			<Box>
-				<TmdbImage imageUrl={item.imageUrl} />
+				<BackgroundImage imageUrl={item.imageUrl} />
 				<Box
 					sx={{
 						position: 'relative',


### PR DESCRIPTION
This PR has various changes, which (in my opinion) improve mainly the history view a bit. These are:

- Episode titles are ellipsized, when they are too long, but movie titles and show names were not. This unifies the behavior, so all titles are ellipsized.
- When initially loading the history list (not from cache) and reaching the end of the list, some items at the very end could be missing. This happened, when the number of items in the history is not divisible by 10, but the API returns more than 10 history items at a time. A fix is included, so these items are shown as well.
- Adds an "unknown" sync status, which is used, as long as there is no associated trakt item. This prevents the sync status from being shown as red / not synced while the history is being loaded and represents the actual internal state a bit better. Instead, it will now show a gray arrow (instead of a red or a green one) while loading.
- Includes information about previous watches for unsynced watches. Until now, it said "not watched" if the watchedAt value could not be associated with a trakt item with a similar watchedAt value, which is technically not correct. Now it says "watched x other times" to let the user know, that they already have an entry in their trakt history, but it was at other points in time. Hovering over this text also shows at which dates they have watchet it.
- Currently, an image provided by the serviceApi will be shown behind the trakt item. This can cause confusion, because if the trakt item is not actually mapped correctly it might seem like it is, because the background image is correct. In this PR this behavior is changed, so images provided by the serviceApi are shown as the background of the service item card and the background is always an image from TMDB for the actual trakt item.
- When disabling the "load images" setting, actually no images are now loaded in the history view, instead of not just collecting the TMDB URLs. Image ULRs provided by the serviceApi would have been loaded anyway.
- Changed / removed some fixed colors to be based on the theme (this is in other parts as well, not just the history view). Mainly, the bottom bar in the settings and history view was set to always be white, which is now changed to be the theme's background color.