### PR TITLE
use alternative api endpoints when www.amazon.* is used as HOST_URL

### DIFF
--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -171,9 +171,14 @@ class _AmazonPrimeApi extends ServiceApi {
 					'//',
 					`//atv-ps${region === 'na' ? '' : `-${region}`}.`
 				);
-				this.PROFILE_URL = `${this.HOST_URL}/region/${region}/api/getProfiles`;
-				this.HISTORY_URL = `${this.HOST_URL}/region/${region}/api/getWatchHistorySettingsPage?widgetArgs=%7B{args}%7D`;
-				this.ENRICHMENTS_URL = `${this.HOST_URL}/region/${region}/api/enrichItemMetadata?metadataToEnrich=%7B%22playback%22%3Atrue%7D&titleIDsToEnrich=%5B{ids}%5D`;
+
+				const apiPath = this.HOST_URL.match(/https:\/\/(?:www\.)?amazon\..+/)
+					? '/gp/video/api'
+					: `/region/${region}/api`;
+
+				this.PROFILE_URL = `${this.HOST_URL}${apiPath}/getProfiles`;
+				this.HISTORY_URL = `${this.HOST_URL}${apiPath}/getWatchHistorySettingsPage?widgetArgs=%7B{args}%7D`;
+				this.ENRICHMENTS_URL = `${this.HOST_URL}${apiPath}/enrichItemMetadata?metadataToEnrich=%7B%22playback%22%3Atrue%7D&titleIDsToEnrich=%5B{ids}%5D`;
 			} catch (err) {
 				if (Shared.errors.validate(err)) {
 					Shared.errors.log(`Failed to activate ${this.id} API`, err);


### PR DESCRIPTION
[${CONFIG_URL}](https://github.com/trakt-tools/universal-trakt-scrobbler/blob/3b2ab19a23a9f322b2911fd7a0f4d2be8a10cbe9/src/services/amazon-prime/AmazonPrimeApi.ts#L159) endpoint could return an amazon url as `defaultVideoWebsite` e.g. https://www.amazon.de

In #286 the endpoints changed in favor of the regional primevideo host url.
But with a host url like https://www.amazon.de, the api endpoints are not valid.
