### PR TITLE
Hotstar: update selector to parse data

### DIFF
--- a/src/services/hotstar/HotstarParser.ts
+++ b/src/services/hotstar/HotstarParser.ts
@@ -5,7 +5,7 @@ import { EpisodeItem, MovieItem } from '@models/Item';
 class _HotstarParser extends ScrobbleParser {
 	constructor() {
 		super(HotstarApi, {
-			watchingUrlRegex: /\/(?:movies|shows)\/\D+(?<id>\d.+)\//,
+			watchingUrlRegex: /(?:movies|shows)\/.+\/(?<id>\d+)\//,
 		});
 	}
 

--- a/src/services/hotstar/HotstarParser.ts
+++ b/src/services/hotstar/HotstarParser.ts
@@ -5,35 +5,36 @@ import { EpisodeItem, MovieItem } from '@models/Item';
 class _HotstarParser extends ScrobbleParser {
 	constructor() {
 		super(HotstarApi, {
-			watchingUrlRegex: /\/(?:movies|tv)\/(?<id>.+)/,
+			watchingUrlRegex: /\/(?:movies|shows)\/\D+(?<id>\d.+)\//,
 		});
 	}
 
 	parseItemFromDom() {
 		const serviceId = this.api.id;
 		const id = this.parseItemIdFromUrl();
-		const titleElement = document.querySelector('.primary-title');
+		const titleElement = document.querySelector(
+			'div#page-container>div>div>div>div>div>div>div>div>div>div.flex.flex-col>div.flex>p.ON_IMAGE.BUTTON1_MEDIUM'
+		);
 
 		if (!titleElement) {
 			return null;
 		}
 
 		const title = titleElement?.textContent ?? '';
-		const seasonEpisodeElement = document.querySelector(
-			'.show-title .meta-data-holder'
-		)?.firstChild;
-		const subTitleElement = document.querySelector('.show-title .meta-data-holder')?.lastChild;
+		const subTitleElement = document.querySelector(
+			'div#page-container>div>div>div>div>div>div>div>div>div>div.flex.flex-col>p.ON_IMAGE_ALT2.BUTTON3_MEDIUM'
+		);
 
 		let seasonId: string | null = null;
 		let episodeId: string | null = null;
-		const subTitle = subTitleElement?.textContent ?? '';
+		let subTitle: string | null = '';
 
-		const matches = /(?<seasonId>[\d]+)\s.(?<episodeId>[\d]+)/.exec(
-			seasonEpisodeElement?.textContent ?? ''
+		const matches = /(?<seasonId>[\d]+)\s.(?<episodeId>[\d]+)\s(?<subTitle>.*)/.exec(
+			subTitleElement?.textContent ?? ''
 		);
 
 		if (matches?.groups) {
-			({ seasonId, episodeId } = matches.groups);
+			({ seasonId, episodeId, subTitle } = matches.groups);
 		}
 
 		if (seasonId) {


### PR DESCRIPTION
Hotstar have major update their website and have different selector then before. 
So, This pull request will make scroble working again.

Movie

![movie](https://github.com/trakt-tools/universal-trakt-scrobbler/assets/18456011/8aff1ff9-1b89-4876-862a-5b331e44ea10)


Shows
![show](https://github.com/trakt-tools/universal-trakt-scrobbler/assets/18456011/b462d3f9-ae2b-444c-978d-cda9aa2d3d10)
