### PR TITLE
HBO Max: Stop matching past first forward slash for item ID

### DIFF
--- a/src/services/hbo-max/HboMaxParser.ts
+++ b/src/services/hbo-max/HboMaxParser.ts
@@ -7,7 +7,7 @@ class _HboMaxParser extends ScrobbleParser {
 			/**
 			 * Format: https://play.hbomax.com/player/urn:hbo:episode:XXXXXXXXXXXXXXXXXXXX
 			 */
-			watchingUrlRegex: /\/(?:player)\/(?<id>.+)/,
+			watchingUrlRegex: /\/(?:player)\/(?<id>[^/]+)/,
 		});
 	}
 }


### PR DESCRIPTION
This avoids failing to parse the correct item ID when the item ID is not the last component of the URL. This seems to happen (for me) when autoplay starts the next episode.