### PR TITLE
Fix bug that does not process items after loading Trakt history

### DIFF
--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -74,7 +74,13 @@ export abstract class ServiceApi {
 						ServiceApi.loadTraktItemHistory(item, caches, correction, processItem, cancelKey)
 					);
 				} else {
-					promises.push(Promise.resolve(item));
+					let promise;
+					if (processItem) {
+						promise = processItem(item);
+					} else {
+						promise = Promise.resolve(item);
+					}
+					promises.push(promise);
 				}
 			}
 			newItems = await Promise.all(promises);


### PR DESCRIPTION
Some items were not being processed after loading the Trakt history, which was leading them not to be filtered.