### PR TITLE
Fix bug that does not reset list after loading

### DIFF
--- a/src/modules/history/components/HistoryList.tsx
+++ b/src/modules/history/components/HistoryList.tsx
@@ -359,6 +359,10 @@ export const HistoryList = (): JSX.Element => {
 				let newItems = await startLoading(store.data.items);
 				newItems = await loadData(newItems);
 				await stopLoading(newItems);
+
+				if (listRef.current) {
+					listRef.current.resetAfterIndex(-1);
+				}
 			}
 		};
 


### PR DESCRIPTION
The history list was not being reset after loading, which was leading it to be incorrectly calculated.