### PR TITLE
Remove tabs permission for Chrome

### DIFF
--- a/src/common/BrowserStorage.ts
+++ b/src/common/BrowserStorage.ts
@@ -890,17 +890,25 @@ class _BrowserStorage {
 					(service) => service.hasScrobbler && options.services[service.id].scrobble
 				);
 				if (originsToAdd.length > 0) {
+					let permissionsToAdd: WebExtManifest.OptionalPermission[] = [];
+					if (Shared.browser == 'firefox') {
+						permissionsToAdd = scrobblerEnabled ? ['tabs'] : [];
+					}
 					permissionPromises.push(
 						browser.permissions.request({
-							permissions: scrobblerEnabled ? ['tabs'] : [],
+							permissions: permissionsToAdd,
 							origins: originsToAdd,
 						})
 					);
 				}
 				if (originsToRemove.length > 0) {
+					let permissionsToRemove: WebExtManifest.OptionalPermission[] = [];
+					if (Shared.browser == 'firefox') {
+						permissionsToRemove = scrobblerEnabled ? [] : ['tabs'];
+					}
 					permissionPromises.push(
 						browser.permissions.remove({
-							permissions: scrobblerEnabled ? [] : ['tabs'],
+							permissions: permissionsToRemove,
 							origins: originsToRemove,
 						})
 					);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -241,7 +241,7 @@ const getManifest = (browserName: string): string => {
 			manifest.background = {
 				service_worker: 'background.js',
 			};
-			manifest.optional_permissions = ['notifications', 'tabs'];
+			manifest.optional_permissions = ['notifications'];
 			// @ts-expect-error This is a newer key, so it's missing from the types.
 			manifest.optional_host_permissions = [
 				'*://api.rollbar.com/*',


### PR DESCRIPTION
The extension has been removed from the Chrome store because it does not need the `tabs` permission, so we need to remove it from the manifest.