### PR TITLE
AmazonPrime: Remove [dt./OV] from movie/show title

### DIFF
--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -381,7 +381,7 @@ class _AmazonPrimeApi extends ServiceApi {
 			let season = 0;
 			if (family) {
 				const [seasonInfo, showInfo] = family.tvAncestors;
-				title = showInfo.catalog.title.replace(' [dt./OV]','');
+				title = showInfo.catalog.title.replace(' [dt./OV]', '');
 				season = seasonInfo.catalog.seasonNumber;
 			}
 			const { episodeNumber: number = 0, title: episodeTitle } = catalog;
@@ -397,7 +397,7 @@ class _AmazonPrimeApi extends ServiceApi {
 				},
 			});
 		} else {
-			const title = catalog.title.replace(' [dt./OV]','');
+			const title = catalog.title.replace(' [dt./OV]', '');
 			item = new MovieItem({
 				serviceId,
 				id,

--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -381,7 +381,7 @@ class _AmazonPrimeApi extends ServiceApi {
 			let season = 0;
 			if (family) {
 				const [seasonInfo, showInfo] = family.tvAncestors;
-				title = showInfo.catalog.title;
+				title = showInfo.catalog.title.replace(' [dt./OV]','');
 				season = seasonInfo.catalog.seasonNumber;
 			}
 			const { episodeNumber: number = 0, title: episodeTitle } = catalog;
@@ -397,7 +397,7 @@ class _AmazonPrimeApi extends ServiceApi {
 				},
 			});
 		} else {
-			const { title } = catalog;
+			const title = catalog.title.replace(' [dt./OV]','');
 			item = new MovieItem({
 				serviceId,
 				id,


### PR DESCRIPTION
Seems like when playing special versions of a show/movie, Prime adds a tag to the title, this messes with the Trakt search. 

German versions seems to add "[dt./OV]", not sure if other tags exists.

Closes #342