### PR TITLE
AmazonPrime: Remove all version tags from movie/show title

### DIFF
--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -375,13 +375,14 @@ class _AmazonPrimeApi extends ServiceApi {
 		const serviceId = this.id;
 		const { catalog, family } = metadata.catalogMetadata;
 		const { id, entityType } = catalog;
+		const versionTagRegex = / \[[\w.]+\/[\w.]+\]$/; // some media with dub/subtitle will add [version/tag] to the title (issue #342)
 
 		if (entityType === 'TV Show' || entityType === 'Bonus Content') {
 			let title = '';
 			let season = 0;
 			if (family) {
 				const [seasonInfo, showInfo] = family.tvAncestors;
-				title = showInfo.catalog.title.replace(' [dt./OV]', '');
+				title = showInfo.catalog.title.replace(versionTagRegex, '');
 				season = seasonInfo.catalog.seasonNumber;
 			}
 			const { episodeNumber: number = 0, title: episodeTitle } = catalog;
@@ -397,7 +398,7 @@ class _AmazonPrimeApi extends ServiceApi {
 				},
 			});
 		} else {
-			const title = catalog.title.replace(' [dt./OV]', '');
+			const title = catalog.title.replace(versionTagRegex, '');
 			item = new MovieItem({
 				serviceId,
 				id,

--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -381,7 +381,7 @@ class _AmazonPrimeApi extends ServiceApi {
 			let season = 0;
 			if (family) {
 				const [seasonInfo, showInfo] = family.tvAncestors;
-				title = showInfo.catalog.title.replace(' [dt./OV]','');
+				title = showInfo.catalog.title.replace(' [dt./OV]', '');
 				season = seasonInfo.catalog.seasonNumber;
 			}
 			const { episodeNumber: number = 0, title: episodeTitle } = catalog;
@@ -397,7 +397,7 @@ class _AmazonPrimeApi extends ServiceApi {
 				},
 			});
 		} else {
-			const title = catalog.title.replace(' [dt./OV]','');
+			const title = catalog.title.replace(' [dt./OV]', '');
 			item = new MovieItem({
 				serviceId,
 				id,

--- a/src/services/amazon-prime/AmazonPrimeApi.ts
+++ b/src/services/amazon-prime/AmazonPrimeApi.ts
@@ -381,7 +381,7 @@ class _AmazonPrimeApi extends ServiceApi {
 			let season = 0;
 			if (family) {
 				const [seasonInfo, showInfo] = family.tvAncestors;
-				title = showInfo.catalog.title;
+				title = showInfo.catalog.title.replace(' [dt./OV]','');
 				season = seasonInfo.catalog.seasonNumber;
 			}
 			const { episodeNumber: number = 0, title: episodeTitle } = catalog;
@@ -397,7 +397,7 @@ class _AmazonPrimeApi extends ServiceApi {
 				},
 			});
 		} else {
-			const { title } = catalog;
+			const title = catalog.title.replace(' [dt./OV]','');
 			item = new MovieItem({
 				serviceId,
 				id,


### PR DESCRIPTION
This is a follow up on the #344 pull request, since there seems to be a lot more tags than just one, I changed it to regex instead. 

Hopefully this will close issue #342 once and for all.