### PR TITLE
Added Amazon Australia to allow for Australian Prime Video customers …

### DIFF
--- a/src/services/amazon-prime/AmazonPrimeService.ts
+++ b/src/services/amazon-prime/AmazonPrimeService.ts
@@ -9,6 +9,7 @@ export const AmazonPrimeService = new Service({
 		'*://*.amazon.com/*',
 		'*://*.amazon.co.jp/*',
 		'*://*.amazon.co.uk/*',
+		'*://*.amazon.com.au/*',
 		'*://*.amazon.de/*',
 	],
 	hasScrobbler: true,


### PR DESCRIPTION
…to login and sync

Users with Amazon.com.au were unable to sync.  Fixing this by adding in the correct hostPatterns entry for the Australian Amazon site.