### PR TITLE
Update Netflix ACTIVATE_URL

### DIFF
--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -172,7 +172,7 @@ class _NetflixApi extends ServiceApi {
 
 		this.HOST_URL = 'https://www.netflix.com';
 		this.API_URL = `${this.HOST_URL}/api/shakti`;
-		this.ACTIVATE_URL = `${this.HOST_URL}/Activate`;
+		this.ACTIVATE_URL = `${this.HOST_URL}/settings/viewed/`;
 
 		this.isActivated = false;
 	}


### PR DESCRIPTION
Potential Fix for https://github.com/trakt-tools/universal-trakt-scrobbler/issues/384

`https://www.netflix.com/settings/viewed` uses the default profile if the user has not previously signed into Netflix and selected their preferred profile to sync.