### PR TITLE
(fix): broken netflix account regex

### DIFF
--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -451,7 +451,7 @@ class _NetflixApi extends ServiceApi {
 	extractSession(text: string): NetflixSession | null {
 		let session: NetflixSession | null = null;
 		const authUrlRegex = /"authURL":"(?<authUrl>.*?)"/;
-		const profileNameRegex = /"userInfo":\{"name":"(?<profileName>.*?)"/;
+		const profileNameRegex = /"userInfo":\{"data":\{"name":"(?<profileName>.*?)"/;
 		const { authUrl } = authUrlRegex.exec(text)?.groups ?? {};
 		const { profileName = null } = profileNameRegex.exec(text)?.groups ?? {};
 		if (authUrl) {


### PR DESCRIPTION
Fixes the broken "User not logged in" by updating the regex in the netflixapi.ts file. fixes #394 #395 