### PR TITLE
fix: New Netflix API history fetching logic.

### DIFF
--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { NetflixService } from '@/netflix/NetflixService';
 import { ServiceApi, ServiceApiSession } from '@apis/ServiceApi';
 import { Requests } from '@common/Requests';
@@ -20,6 +21,7 @@ export interface NetflixGlobalObject {
 				data: {
 					authURL: string;
 					name: string | null;
+					userGuid?: string;
 				};
 			};
 			serverDefs: {
@@ -39,6 +41,7 @@ export interface NetflixPlayerState {
 
 export interface NetflixSession extends ServiceApiSession {
 	authUrl: string;
+	userGuid?: string;
 }
 
 export interface NetflixScrobbleSession {
@@ -160,6 +163,16 @@ export type NetflixHistoryEpisodeItemWithMetadata = NetflixHistoryEpisodeItem &
 export type NetflixHistoryMovieItemWithMetadata = NetflixHistoryMovieItem &
 	NetflixMetadataMovieItem;
 
+export interface NetflixAuiHistoryResponse {
+	jsonGraph: {
+		aui: {
+			viewingActivity?: {
+				value?: { viewedItems?: NetflixHistoryItem[] };
+			};
+		};
+	};
+}
+
 class _NetflixApi extends ServiceApi {
 	HOST_URL: string;
 	API_URL: string;
@@ -213,15 +226,116 @@ class _NetflixApi extends ServiceApi {
 		if (!this.session) {
 			throw new Error('Invalid session');
 		}
-		const responseText = await Requests.send({
-			url: `${this.API_URL}/mre/viewingactivity?languages=en-US&authURL=${this.session.authUrl}&pg=${this.nextHistoryPage}`,
-			method: 'GET',
-			cancelKey,
-		});
-		const responseJson = JSON.parse(responseText) as NetflixHistoryResponse;
-		const responseItems = responseJson?.viewedItems ?? [];
+
+		const pageSize = 50;
+		const callPath = `["aui","viewingActivity",${this.nextHistoryPage},${pageSize}]`;
+		const encodedCallPath = encodeURIComponent(callPath);
+		const url = `${this.HOST_URL}/api/aui/pathEvaluator/web/%5E2.0.0?method=call&callPath=${encodedCallPath}&falcor_server=0.1.0`;
+
+		// URL-encode the JSON payload for application/x-www-form-urlencoded content type
+		const paramValue = JSON.stringify({ guid: this.session.userGuid });
+		const body = `param=${encodeURIComponent(paramValue)}`;
+
+		const headers = {
+			'x-netflix.request.routing':
+				'{"path":"/nq/aui/endpoint/%5E1.0.0-web/pathEvaluator","control_tag":"auinqweb"}',
+		};
+
+		const MAX_RETRIES = 10;
+		let responseText: string | undefined;
+		for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+			try {
+				responseText = await Requests.send({
+					url,
+					method: 'POST',
+					body,
+					headers,
+					cancelKey,
+				});
+
+				if (responseText) {
+					break;
+				}
+			} catch (err) {
+				if (attempt === MAX_RETRIES) {
+					throw err;
+				}
+			}
+		}
+
+		if (!responseText) {
+			throw new Error('Failed to fetch history from Netflix API');
+		}
+
+		// Type-safe parsing and access
+		const responseJson: NetflixAuiHistoryResponse = JSON.parse(responseText);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const responseItems: NetflixHistoryItem[] = [];
+		const aui = responseJson?.jsonGraph?.aui;
+		const viewingActivity = aui?.viewingActivity;
+		const value = viewingActivity?.value;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const viewedItemsUnknown: unknown = value?.viewedItems;
+		if (Array.isArray(viewedItemsUnknown)) {
+			for (const item of viewedItemsUnknown) {
+				if (
+					item &&
+					typeof item === 'object' &&
+					'movieID' in item &&
+					typeof (item as { movieID?: unknown }).movieID === 'number' &&
+					'title' in item &&
+					typeof (item as { title?: unknown }).title === 'string' &&
+					'date' in item &&
+					typeof (item as { date?: unknown }).date === 'number' &&
+					'bookmark' in item &&
+					typeof (item as { bookmark?: unknown }).bookmark === 'number' &&
+					'duration' in item &&
+					typeof (item as { duration?: unknown }).duration === 'number'
+				) {
+					const movieID = (item as { movieID: number }).movieID;
+					const title = (item as { title: string }).title;
+					const date = (item as { date: number }).date;
+					const bookmark = (item as { bookmark: number }).bookmark;
+					const duration = (item as { duration: number }).duration;
+					if (
+						'series' in item &&
+						typeof (item as { series?: unknown }).series === 'number' &&
+						'episodeTitle' in item &&
+						typeof (item as { episodeTitle?: unknown }).episodeTitle === 'string' &&
+						'seriesTitle' in item &&
+						typeof (item as { seriesTitle?: unknown }).seriesTitle === 'string'
+					) {
+						const series = (item as { series: number }).series;
+						const episodeTitle = (item as { episodeTitle: string }).episodeTitle;
+						const seriesTitle = (item as { seriesTitle: string }).seriesTitle;
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						responseItems.push({
+							bookmark,
+							date,
+							duration,
+							movieID,
+							title,
+							series,
+							episodeTitle,
+							seriesTitle,
+						});
+					} else {
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						responseItems.push({
+							bookmark,
+							date,
+							duration,
+							movieID,
+							title,
+						});
+					}
+				}
+			}
+		}
+
 		this.nextHistoryPage += 1;
-		this.hasReachedHistoryEnd = responseItems.length === 0;
+		this.hasReachedHistoryEnd = Array.isArray(responseItems) && responseItems.length === 0;
+
 		return responseItems;
 	}
 
@@ -452,10 +566,15 @@ class _NetflixApi extends ServiceApi {
 		let session: NetflixSession | null = null;
 		const authUrlRegex = /"authURL":"(?<authUrl>.*?)"/;
 		const profileNameRegex = /"userInfo":\{"data":\{"name":"(?<profileName>.*?)"/;
+		const userGuidRegex = /"userInfo":\{"data":\{[^}]*"userGuid":"(?<userGuid>.*?)"/;
 		const { authUrl } = authUrlRegex.exec(text)?.groups ?? {};
 		const { profileName = null } = profileNameRegex.exec(text)?.groups ?? {};
+		const { userGuid = undefined } = userGuidRegex.exec(text)?.groups ?? {};
 		if (authUrl) {
 			session = { authUrl, profileName };
+			if (userGuid) {
+				session.userGuid = userGuid;
+			}
 		}
 		return session;
 	}
@@ -468,11 +587,37 @@ Shared.functionsToInject[`${NetflixService.id}-session`] = () => {
 		const { userInfo } = netflix.reactContext.models;
 		const authUrl = userInfo.data.authURL;
 		const profileName = userInfo.data.name;
+		const userGuid = userInfo.data.userGuid;
 		if (authUrl) {
 			session = { authUrl, profileName };
+			if (userGuid) {
+				session.userGuid = userGuid;
+			}
 		}
 	}
 	return session;
+};
+
+const isNetflixHistoryItemArray = (arr: unknown): arr is NetflixHistoryItem[] => {
+	return (
+		Array.isArray(arr) &&
+		arr.every((item) => {
+			if (!item || typeof item !== 'object') return false;
+			const obj = item as { [key: string]: unknown };
+			return (
+				'movieID' in obj &&
+				typeof obj.movieID === 'number' &&
+				'title' in obj &&
+				typeof obj.title === 'string' &&
+				'date' in obj &&
+				typeof obj.date === 'number' &&
+				'bookmark' in obj &&
+				typeof obj.bookmark === 'number' &&
+				'duration' in obj &&
+				typeof obj.duration === 'number'
+			);
+		})
+	);
 };
 
 export const NetflixApi = new _NetflixApi();

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { NetflixService } from '@/netflix/NetflixService';
 import { ServiceApi, ServiceApiSession } from '@apis/ServiceApi';
 import { Requests } from '@common/Requests';
@@ -268,70 +267,8 @@ class _NetflixApi extends ServiceApi {
 		}
 
 		// Type-safe parsing and access
-		const responseJson: NetflixAuiHistoryResponse = JSON.parse(responseText);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const responseItems: NetflixHistoryItem[] = [];
-		const aui = responseJson?.jsonGraph?.aui;
-		const viewingActivity = aui?.viewingActivity;
-		const value = viewingActivity?.value;
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const viewedItemsUnknown: unknown = value?.viewedItems;
-		if (Array.isArray(viewedItemsUnknown)) {
-			for (const item of viewedItemsUnknown) {
-				if (
-					item &&
-					typeof item === 'object' &&
-					'movieID' in item &&
-					typeof (item as { movieID?: unknown }).movieID === 'number' &&
-					'title' in item &&
-					typeof (item as { title?: unknown }).title === 'string' &&
-					'date' in item &&
-					typeof (item as { date?: unknown }).date === 'number' &&
-					'bookmark' in item &&
-					typeof (item as { bookmark?: unknown }).bookmark === 'number' &&
-					'duration' in item &&
-					typeof (item as { duration?: unknown }).duration === 'number'
-				) {
-					const movieID = (item as { movieID: number }).movieID;
-					const title = (item as { title: string }).title;
-					const date = (item as { date: number }).date;
-					const bookmark = (item as { bookmark: number }).bookmark;
-					const duration = (item as { duration: number }).duration;
-					if (
-						'series' in item &&
-						typeof (item as { series?: unknown }).series === 'number' &&
-						'episodeTitle' in item &&
-						typeof (item as { episodeTitle?: unknown }).episodeTitle === 'string' &&
-						'seriesTitle' in item &&
-						typeof (item as { seriesTitle?: unknown }).seriesTitle === 'string'
-					) {
-						const series = (item as { series: number }).series;
-						const episodeTitle = (item as { episodeTitle: string }).episodeTitle;
-						const seriesTitle = (item as { seriesTitle: string }).seriesTitle;
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-						responseItems.push({
-							bookmark,
-							date,
-							duration,
-							movieID,
-							title,
-							series,
-							episodeTitle,
-							seriesTitle,
-						});
-					} else {
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-						responseItems.push({
-							bookmark,
-							date,
-							duration,
-							movieID,
-							title,
-						});
-					}
-				}
-			}
-		}
+		const responseJson = JSON.parse(responseText) as NetflixAuiHistoryResponse;
+		const responseItems = responseJson.jsonGraph.aui.viewingActivity?.value?.viewedItems ?? [];
 
 		this.nextHistoryPage += 1;
 		this.hasReachedHistoryEnd = Array.isArray(responseItems) && responseItems.length === 0;
@@ -596,28 +533,6 @@ Shared.functionsToInject[`${NetflixService.id}-session`] = () => {
 		}
 	}
 	return session;
-};
-
-const isNetflixHistoryItemArray = (arr: unknown): arr is NetflixHistoryItem[] => {
-	return (
-		Array.isArray(arr) &&
-		arr.every((item) => {
-			if (!item || typeof item !== 'object') return false;
-			const obj = item as { [key: string]: unknown };
-			return (
-				'movieID' in obj &&
-				typeof obj.movieID === 'number' &&
-				'title' in obj &&
-				typeof obj.title === 'string' &&
-				'date' in obj &&
-				typeof obj.date === 'number' &&
-				'bookmark' in obj &&
-				typeof obj.bookmark === 'number' &&
-				'duration' in obj &&
-				typeof obj.duration === 'number'
-			);
-		})
-	);
 };
 
 export const NetflixApi = new _NetflixApi();


### PR DESCRIPTION
using the new endpoint for history collection: 

`https://www.netflix.com/api/aui/pathEvaluator/web/^2.0.0?method=call&callPath=["aui","viewingActivity",1,50]&falcor_server=0.1.0`

- Also the reason i have added MAX_RETRIES upto 10 is the netflix api just fails randomly and then succeeds ? so this was the legible solution i found for it