### PR TITLE
Fix for Netflix shows disappearing issue

### DIFF
--- a/src/modules/history/components/HistoryList.tsx
+++ b/src/modules/history/components/HistoryList.tsx
@@ -197,14 +197,18 @@ export const HistoryList = (): JSX.Element => {
 		for (const item of items) {
 			const doHide = item.doHide();
 			const isSelectable = item.isSelectable();
-			if (item.isHidden !== doHide || (item.isSelected && !isSelectable)) {
+
+			// Don't hide items that are still loading or not selectable - they need time to be processed
+			const shouldHide = doHide && !item.isLoading && isSelectable;
+
+			if (item.isHidden !== shouldHide || (item.isSelected && !isSelectable)) {
 				if (index < 0) {
 					index = item.index;
 				}
 
 				const newItem = item.clone();
-				if (item.isHidden !== doHide) {
-					newItem.isHidden = doHide;
+				if (item.isHidden !== shouldHide) {
+					newItem.isHidden = shouldHide;
 				}
 				if (item.isSelected && !isSelectable) {
 					newItem.isSelected = false;


### PR DESCRIPTION
#429


ESSENTIAL CHANGE:
- Fixed hiding logic in HistoryList.tsx checkHiddenSelected function
- Changed: const shouldHide = doHide && && isSelectable;
- Prevents non-selectable items from being hidden during processing

ROOT CAUSE:
Netflix shows disappeared because the hiding logic incorrectly marked non-selectable items (items without Trakt metadata) as hidden, causing them to render with 0 height and become invisible in the virtualized list.

SOLUTION:
The fix ensures items remain visible while they are loading or not yet selectable, allowing time for Trakt metadata to be fetched and processed. Only items that are fully processed AND selectable can be hidden.