### PR TITLE
fix(disneplus): Item detection and playback progress detection with p…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 /.idea/
 /universal-trakt-scrobbler.iml
 package-lock.json
+.DS_Store

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
 node = "24"
+pnpm = "latest"


### PR DESCRIPTION
…ause for new player

- Closes #326
- Closes #345
- Closes #412

Item detection with URL: 
<img width="1245" height="287" alt="SCR-20260124-pcqo" src="https://github.com/user-attachments/assets/f743e28d-cfe0-4bae-968c-7e1c27dbaae4" />

Progress bar uses custom div with aria labels under progress-bar wecomponent:
https://github.com/user-attachments/assets/76a59501-fbfb-4f2e-b3f4-c596fc1457e3

Pause detection is done using toggle-play-plause > button which has `pause-button` or `play-button`:
https://github.com/user-attachments/assets/9c7e906d-1ac3-450a-8479-858b3a797ef8

Pausing demo:
https://github.com/user-attachments/assets/d584524c-4fd7-414e-946c-05e51261685d

