### PR TITLE
Improve episode matching and error handling for Crunchyroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 |   Amazon Prime    |    ✔️    |  ✔️  | Scrobbling only works in English |
 |       AMC+        |    ✔️    |  ❌  | -                                |
 |       Crave       |    ✔️    |  ✔️  | -                                |
-|    Crunchyroll    |    ❌    |  ✔️  | Can't identify movies as movies  |
+|    Crunchyroll    |    ❌    |  ✔️  | -                                |
 |    discovery+     |    ✔️    |  ✔️  | -                                |
 |      Disney+      |    ✔️    |  ❌  | -                                |
 |        Go3        |    ✔️    |  ❌  | -                                |

--- a/src/apis/TmdbApi.ts
+++ b/src/apis/TmdbApi.ts
@@ -34,6 +34,22 @@ export interface ImagesDatabaseResponse {
 	result: Partial<Record<string, string>>;
 }
 
+export interface TmdbEpisodeSearchResult {
+	season_number: number;
+	episode_number: number;
+	name: string;
+	id: number;
+}
+
+export interface TmdbTvSearchResult {
+	id: number;
+	name: string;
+	first_air_date?: string;
+	origin_country?: string[];
+	genre_ids?: number[];
+	vote_count?: number;
+}
+
 /**
  * @see https://developers.themoviedb.org/3/getting-started/introduction
  */
@@ -215,6 +231,125 @@ class _TmdbApi {
 		}
 		await Cache.set({ tmdbImageUrls: cache });
 		return newItems;
+	}
+
+	/**
+	 * Searches for a TV show by title on TMDB.
+	 * If year is provided, filters results to match the year.
+	 * If serviceId is 'crunchyroll', prioritizes anime (genre 16) and Japanese productions.
+	 */
+	async searchTvShow(
+		title: string,
+		year?: number,
+		serviceId?: string
+	): Promise<TmdbTvSearchResult | null> {
+		try {
+			const url = `${this.API_URL}/search/tv?api_key=${Shared.tmdbApiKey}&query=${encodeURIComponent(title)}`;
+
+			const responseText = await Requests.send({
+				url: url,
+				method: 'GET',
+			});
+			const response = JSON.parse(responseText) as { results?: TmdbTvSearchResult[] };
+
+			if (!response.results || response.results.length === 0) {
+				return null;
+			}
+
+			// If year is provided, try to find a match with the same year
+			if (year) {
+				const matchingYear = response.results.find((result) => {
+					if (!result.first_air_date) return false;
+					const resultYear = parseInt(result.first_air_date.split('-')[0], 10);
+					return resultYear === year;
+				});
+				if (matchingYear) {
+					return matchingYear;
+				}
+			}
+
+			// Only prioritize anime for Crunchyroll (they primarily offer anime)
+			if (serviceId === 'crunchyroll') {
+				// Genre ID 16 = Animation
+				const animeResults = response.results.filter(
+					(result) => result.genre_ids?.includes(16) || result.origin_country?.includes('JP')
+				);
+
+				if (animeResults.length > 0) {
+					// Sort by popularity (vote_count) and prefer older series (original versions)
+					animeResults.sort((a, b) => {
+						// First, prioritize by vote count (higher = more popular)
+						const voteCountDiff = (b.vote_count || 0) - (a.vote_count || 0);
+						if (voteCountDiff !== 0) return voteCountDiff;
+
+						// If vote counts are similar, prefer older (original) series
+						const aYear = a.first_air_date ? parseInt(a.first_air_date.split('-')[0], 10) : 9999;
+						const bYear = b.first_air_date ? parseInt(b.first_air_date.split('-')[0], 10) : 9999;
+						return aYear - bYear;
+					});
+					return animeResults[0];
+				}
+			}
+
+			// Return first result (default TMDB ranking)
+			return response.results[0];
+		} catch (err) {
+			if (Shared.errors.validate(err)) {
+				Shared.errors.warning('Failed to search TV show on TMDB.', err);
+			}
+			return null;
+		}
+	}
+
+	/**
+	 * Finds an episode by title within a TMDB TV show.
+	 * Returns the season and episode number if found.
+	 */
+	async findEpisodeByTitle(
+		tmdbShowId: number,
+		episodeTitle: string
+	): Promise<{ season: number; episode: number } | null> {
+		try {
+			// Get all seasons for the show
+			const url = `${this.API_URL}/tv/${tmdbShowId}?api_key=${Shared.tmdbApiKey}`;
+			const responseText = await Requests.send({
+				url: url,
+				method: 'GET',
+			});
+			const show = JSON.parse(responseText) as { seasons?: { season_number: number }[] };
+
+			if (!show.seasons) {
+				return null;
+			}
+
+			// Search through each season's episodes
+			for (const season of show.seasons) {
+				if (season.season_number === 0) continue; // Skip specials
+
+				const seasonUrl = `${this.API_URL}/tv/${tmdbShowId}/season/${season.season_number}?api_key=${Shared.tmdbApiKey}`;
+				const seasonResponse = await Requests.send({
+					url: seasonUrl,
+					method: 'GET',
+				});
+				const seasonData = JSON.parse(seasonResponse) as { episodes?: TmdbEpisodeSearchResult[] };
+
+				const match = seasonData.episodes?.find(
+					(ep) => ep.name.toLowerCase() === episodeTitle.toLowerCase()
+				);
+
+				if (match) {
+					return {
+						season: match.season_number,
+						episode: match.episode_number,
+					};
+				}
+			}
+		} catch (err) {
+			if (Shared.errors.validate(err)) {
+				Shared.errors.warning('Failed to find episode by title on TMDB.', err);
+			}
+		}
+		return null;
 	}
 }
 

--- a/src/apis/TmdbApi.ts
+++ b/src/apis/TmdbApi.ts
@@ -324,8 +324,6 @@ class _TmdbApi {
 
 			// Search through each season's episodes
 			for (const season of show.seasons) {
-				if (season.season_number === 0) continue; // Skip specials
-
 				const seasonUrl = `${this.API_URL}/tv/${tmdbShowId}/season/${season.season_number}?api_key=${Shared.tmdbApiKey}`;
 				const seasonResponse = await Requests.send({
 					url: seasonUrl,

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -289,26 +289,59 @@ class _TraktSearch extends TraktApi {
 		const showItem = await this.findShow(item, caches, cancelKey);
 		await this.activate();
 
-		const { foundSeason, foundEpisodeNumber } = await this.resolveAbsoluteEpisodeNumber(
-			item,
-			showItem,
-			cancelKey
-		);
+		// Try with the provided season/episode numbers first
+		let url = this.getEpisodeUrl(item, showItem.show.ids.trakt);
+		let responseText: string | null = null;
 
-		const url = this.buildEpisodeUrl(item, showItem, foundSeason, foundEpisodeNumber);
-		const responseText = await this.tryFetchEpisodeWithTmdbFallback(
-			url,
-			item,
-			showItem,
-			foundSeason,
-			foundEpisodeNumber,
-			cancelKey
-		);
+		try {
+			responseText = await this.requests.send({
+				url: url,
+				method: 'GET',
+				cancelKey,
+			});
+		} catch (error) {
+			// If provided numbers don't work, try TMDB fallback first
+			if (
+				Shared.errors.validate(error) &&
+				((error as RequestError).status === 404 || (error as RequestError).status === -1) &&
+				item.title &&
+				!item.title.startsWith('Episode')
+			) {
+				const tmdbResult = await this.tryTmdbFallback(item, showItem, cancelKey);
+				if (tmdbResult) {
+					return this.parseEpisodeResponse(tmdbResult, item, showItem);
+				}
+
+				// If TMDB also fails, try treating numbers as absolute
+				const { foundSeason, foundEpisodeNumber } = await this.tryAbsoluteEpisodeNumberFallback(
+					item,
+					showItem,
+					cancelKey
+				);
+
+				if (foundSeason !== null) {
+					const absoluteUrl = this.buildEpisodeUrl(item, showItem, foundSeason, foundEpisodeNumber);
+					try {
+						responseText = await this.requests.send({
+							url: absoluteUrl,
+							method: 'GET',
+							cancelKey,
+						});
+					} catch (_absoluteError) {
+						throw error; // Throw original error if absolute fallback also fails
+					}
+				} else {
+					throw error;
+				}
+			} else {
+				throw error;
+			}
+		}
 
 		return this.parseEpisodeResponse(responseText, item, showItem);
 	}
 
-	private async resolveAbsoluteEpisodeNumber(
+	private async tryAbsoluteEpisodeNumberFallback(
 		item: EpisodeItem,
 		showItem: TraktSearchShowItem,
 		cancelKey: string
@@ -316,27 +349,16 @@ class _TraktSearch extends TraktApi {
 		let foundSeason: number | null = null;
 		let foundEpisodeNumber = 0;
 
-		if (!item.isAbsolute || !item.number) {
+		if (!item.number) {
 			return { foundSeason, foundEpisodeNumber };
 		}
 
 		const seasons = await this.fetchSeasons(showItem, cancelKey);
 
-		// 1. Try to treat it as a relative number first (if season info matches)
-		if (item.season) {
-			const currentSeason = seasons.find((s) => s.number === item.season);
-			if (currentSeason && item.number <= currentSeason.episode_count) {
-				foundSeason = currentSeason.number;
-				foundEpisodeNumber = item.number;
-			}
-		}
-
-		// 2. Fallback: If not found as relative, treat as absolute
-		if (foundSeason === null) {
-			const result = this.calculateAbsoluteEpisodePosition(item, seasons);
-			foundSeason = result.season;
-			foundEpisodeNumber = result.episode;
-		}
+		// Try to treat provided numbers as absolute (e.g., anime episodes from Crunchyroll)
+		const result = this.calculateAbsoluteEpisodePosition(item, seasons);
+		foundSeason = result.season;
+		foundEpisodeNumber = result.episode;
 
 		return { foundSeason, foundEpisodeNumber };
 	}
@@ -397,40 +419,9 @@ class _TraktSearch extends TraktApi {
 			const tempItem = item.clone();
 			tempItem.season = foundSeason;
 			tempItem.number = foundEpisodeNumber;
-			tempItem.isAbsolute = false;
 			return this.getEpisodeUrl(tempItem, showItem.show.ids.trakt);
 		}
 		return this.getEpisodeUrl(item, showItem.show.ids.trakt);
-	}
-
-	private async tryFetchEpisodeWithTmdbFallback(
-		url: string,
-		item: EpisodeItem,
-		showItem: TraktSearchShowItem,
-		foundSeason: number | null,
-		foundEpisodeNumber: number,
-		cancelKey: string
-	): Promise<string> {
-		try {
-			return await this.requests.send({
-				url: url,
-				method: 'GET',
-				cancelKey,
-			});
-		} catch (error) {
-			if (
-				Shared.errors.validate(error) &&
-				((error as RequestError).status === 404 || (error as RequestError).status === -1) &&
-				item.title &&
-				!item.title.startsWith('Episode')
-			) {
-				const tmdbResult = await this.tryTmdbFallback(item, showItem, cancelKey);
-				if (tmdbResult) {
-					return tmdbResult;
-				}
-			}
-			throw error;
-		}
 	}
 
 	private async tryTmdbFallback(

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -286,23 +286,198 @@ class _TraktSearch extends TraktApi {
 		caches: CacheItems<['traktItems', 'urlsToTraktItems']>,
 		cancelKey = 'default'
 	): Promise<TraktSearchEpisodeItem> {
-		let episodeItem: TraktSearchEpisodeItemEpisode;
 		const showItem = await this.findShow(item, caches, cancelKey);
 		await this.activate();
-		const responseText = await this.requests.send({
-			url: this.getEpisodeUrl(item, showItem.show.ids.trakt),
+
+		const { foundSeason, foundEpisodeNumber } = await this.resolveAbsoluteEpisodeNumber(
+			item,
+			showItem,
+			cancelKey
+		);
+
+		const url = this.buildEpisodeUrl(item, showItem, foundSeason, foundEpisodeNumber);
+		const responseText = await this.tryFetchEpisodeWithTmdbFallback(
+			url,
+			item,
+			showItem,
+			foundSeason,
+			foundEpisodeNumber,
+			cancelKey
+		);
+
+		return this.parseEpisodeResponse(responseText, item, showItem);
+	}
+
+	private async resolveAbsoluteEpisodeNumber(
+		item: EpisodeItem,
+		showItem: TraktSearchShowItem,
+		cancelKey: string
+	): Promise<{ foundSeason: number | null; foundEpisodeNumber: number }> {
+		let foundSeason: number | null = null;
+		let foundEpisodeNumber = 0;
+
+		if (!item.isAbsolute || !item.number) {
+			return { foundSeason, foundEpisodeNumber };
+		}
+
+		const seasons = await this.fetchSeasons(showItem, cancelKey);
+
+		// 1. Try to treat it as a relative number first (if season info matches)
+		if (item.season) {
+			const currentSeason = seasons.find((s) => s.number === item.season);
+			if (currentSeason && item.number <= currentSeason.episode_count) {
+				foundSeason = currentSeason.number;
+				foundEpisodeNumber = item.number;
+			}
+		}
+
+		// 2. Fallback: If not found as relative, treat as absolute
+		if (foundSeason === null) {
+			const result = this.calculateAbsoluteEpisodePosition(item, seasons);
+			foundSeason = result.season;
+			foundEpisodeNumber = result.episode;
+		}
+
+		return { foundSeason, foundEpisodeNumber };
+	}
+
+	private async fetchSeasons(
+		showItem: TraktSearchShowItem,
+		cancelKey: string
+	): Promise<{ number: number; episode_count: number }[]> {
+		const seasonsResponse = await this.requests.send({
+			url: `${this.API_URL}/shows/${showItem.show.ids.trakt}/seasons?extended=full`,
 			method: 'GET',
 			cancelKey,
 		});
+		return (
+			JSON.parse(seasonsResponse) as {
+				number: number;
+				episode_count: number;
+			}[]
+		).filter((s) => s.number > 0); // Filter out specials (season 0)
+	}
+
+	private calculateAbsoluteEpisodePosition(
+		item: EpisodeItem,
+		seasons: { number: number; episode_count: number }[]
+	): { season: number; episode: number } {
+		const maxSeason = seasons.length > 0 ? seasons[seasons.length - 1].number : 0;
+
+		// Heuristic: If the episode number is small (e.g. <= 25) and the season is > max known season,
+		// it's likely a new season that Trakt doesn't have yet.
+		// In this case, absolute calculation would erroneously map it to Season 1.
+		if (item.number && item.number <= 25 && item.season && item.season > maxSeason) {
+			return { season: item.season, episode: item.number };
+		}
+
+		let absoluteCount = 0;
+		seasons.sort((a, b) => a.number - b.number);
+		for (const season of seasons) {
+			if (item.number && item.number <= absoluteCount + season.episode_count) {
+				return {
+					season: season.number,
+					episode: item.number - absoluteCount,
+				};
+			}
+			absoluteCount += season.episode_count;
+		}
+
+		// Fallback: Use the original provided season and number if absolute calc failed
+		return { season: item.season || 0, episode: item.number || 0 };
+	}
+
+	private buildEpisodeUrl(
+		item: EpisodeItem,
+		showItem: TraktSearchShowItem,
+		foundSeason: number | null,
+		foundEpisodeNumber: number
+	): string {
+		if (foundSeason !== null) {
+			const tempItem = item.clone();
+			tempItem.season = foundSeason;
+			tempItem.number = foundEpisodeNumber;
+			tempItem.isAbsolute = false;
+			return this.getEpisodeUrl(tempItem, showItem.show.ids.trakt);
+		}
+		return this.getEpisodeUrl(item, showItem.show.ids.trakt);
+	}
+
+	private async tryFetchEpisodeWithTmdbFallback(
+		url: string,
+		item: EpisodeItem,
+		showItem: TraktSearchShowItem,
+		foundSeason: number | null,
+		foundEpisodeNumber: number,
+		cancelKey: string
+	): Promise<string> {
+		try {
+			return await this.requests.send({
+				url: url,
+				method: 'GET',
+				cancelKey,
+			});
+		} catch (error) {
+			if (
+				Shared.errors.validate(error) &&
+				((error as RequestError).status === 404 || (error as RequestError).status === -1) &&
+				item.title &&
+				!item.title.startsWith('Episode')
+			) {
+				const tmdbResult = await this.tryTmdbFallback(item, showItem, cancelKey);
+				if (tmdbResult) {
+					return tmdbResult;
+				}
+			}
+			throw error;
+		}
+	}
+
+	private async tryTmdbFallback(
+		item: EpisodeItem,
+		showItem: TraktSearchShowItem,
+		cancelKey: string
+	): Promise<string | null> {
+		try {
+			const { TmdbApi } = await import('@apis/TmdbApi');
+			const tmdbShow = await TmdbApi.searchTvShow(item.show.title, item.show.year, item.serviceId);
+
+			if (!tmdbShow) {
+				return null;
+			}
+
+			const tmdbEpisode = await TmdbApi.findEpisodeByTitle(tmdbShow.id, item.title);
+
+			if (!tmdbEpisode) {
+				return null;
+			}
+
+			const tmdbBasedUrl = `${this.SHOWS_URL}/${showItem.show.ids.trakt}/seasons/${tmdbEpisode.season}/episodes/${tmdbEpisode.episode}?extended=full`;
+			return await this.requests.send({
+				url: tmdbBasedUrl,
+				method: 'GET',
+				cancelKey,
+			});
+		} catch (_tmdbError) {
+			return null;
+		}
+	}
+
+	private parseEpisodeResponse(
+		responseText: string,
+		item: EpisodeItem,
+		showItem: TraktSearchShowItem
+	): TraktSearchEpisodeItem {
 		const response = JSON.parse(responseText) as TraktEpisodeItemEpisode | TraktSearchEpisodeItem[];
+
 		if (Array.isArray(response)) {
 			return this.findEpisodeByTitle(item, showItem, response);
-		} else {
-			episodeItem = {
-				episode: response,
-			};
-			return Object.assign({}, episodeItem, showItem);
 		}
+
+		return {
+			episode: response,
+			show: showItem.show,
+		};
 	}
 
 	findEpisodeByTitle(

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -47,6 +47,30 @@ class _Requests {
 			const response = await this.fetch(request, tabId);
 			responseStatus = response.status;
 			responseText = await response.text();
+
+			// Check for Cloudflare rate limiting HTML response
+			if (responseText.includes('Cloudflare') && responseText.includes('Ray ID:')) {
+				// Extract error code if present (e.g., Error 1015)
+				const errorMatch = responseText.match(/Error\s*(\d+)/);
+				const errorCode = errorMatch ? errorMatch[1] : 'unknown';
+
+				// Set appropriate status code for rate limiting
+				if (responseText.includes('rate limit') || errorCode === '1015') {
+					responseStatus = 429; // Use standard rate limit status
+					// Cloudflare doesn't provide Retry-After header in HTML error pages
+					// Use a reasonable default wait time (60 seconds)
+					const retryAfter = 60000;
+					console.warn(
+						`Cloudflare rate limit detected (Error ${errorCode}). Retrying in ${retryAfter / 1000}s`
+					);
+					setTimeout(() => void this.sendDirectly(request, tabId, resolve, reject), retryAfter);
+					return;
+				}
+
+				responseStatus = responseStatus || 503;
+				throw `Cloudflare blocked request (Error ${errorCode})`;
+			}
+
 			if (responseStatus === 429) {
 				const retryAfterStr = response.headers.get('Retry-After');
 				if (retryAfterStr) {
@@ -59,19 +83,35 @@ class _Requests {
 				throw responseText;
 			}
 		} catch (err) {
+			// Handle manually thrown errors from above (where status >= 400)
+			if (typeof err === 'string' && responseStatus >= 400) {
+				reject(
+					new RequestError({
+						request,
+						status: responseStatus, // Use the captured status code
+						text: responseText,
+						isCanceled: request.signal?.aborted ?? false,
+					})
+				);
+				return;
+			}
+
 			let errRespStatus = -1;
-			let errRespData: string | undefined = undefined;
-			// Making sure all accessed data is actually there
+			let errRespData: undefined | string = undefined;
+
+			// Attempt to extract status from error object if it mimics axios/similar structure, or default to -1
 			if (
 				typeof err === 'object' &&
 				err &&
 				'response' in err &&
-				typeof err.response === 'object' &&
-				err.response
+				typeof (err as any).response === 'object' &&
+				(err as any).response
 			) {
-				if ('status' in err.response) errRespStatus = err.response.status as number;
-				if ('data' in err.response) errRespData = err.response.data as string;
+				const errAny = err as any;
+				if ('status' in errAny.response) errRespStatus = errAny.response.status as number;
+				if ('data' in errAny.response) errRespData = errAny.response.data as string;
 			}
+
 			reject(
 				new RequestError({
 					request,
@@ -80,6 +120,7 @@ class _Requests {
 					isCanceled: request.signal?.aborted ?? false,
 				})
 			);
+			return;
 		}
 		resolve(responseText);
 	}

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -56,7 +56,6 @@ export interface EpisodeItemValues extends BaseItemValues {
 	number: number;
 	show: ShowItemValues;
 	trakt?: TraktEpisodeItemValues | null;
-	isAbsolute?: boolean;
 }
 
 export type EpisodeItemParams = Omit<EpisodeItemValues, 'type' | 'show' | 'trakt'> & {
@@ -189,7 +188,6 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 	number: number;
 	show: ShowItem;
 	trakt?: TraktEpisodeItem | null;
-	isAbsolute?: boolean;
 
 	constructor(values: EpisodeItemParams) {
 		super(values);
@@ -197,7 +195,6 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 		this.number = values.number;
 		this.show = new ShowItem(values.show);
 		this.trakt = values.trakt && new TraktEpisodeItem(values.trakt);
-		this.isAbsolute = values.isAbsolute;
 	}
 
 	save(): EpisodeItemValues {
@@ -208,7 +205,6 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 			number: this.number,
 			show: this.show.save(),
 			trakt: this.trakt?.save(),
-			isAbsolute: this.isAbsolute,
 		};
 	}
 

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -56,6 +56,7 @@ export interface EpisodeItemValues extends BaseItemValues {
 	number: number;
 	show: ShowItemValues;
 	trakt?: TraktEpisodeItemValues | null;
+	isAbsolute?: boolean;
 }
 
 export type EpisodeItemParams = Omit<EpisodeItemValues, 'type' | 'show' | 'trakt'> & {
@@ -188,6 +189,7 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 	number: number;
 	show: ShowItem;
 	trakt?: TraktEpisodeItem | null;
+	isAbsolute?: boolean;
 
 	constructor(values: EpisodeItemParams) {
 		super(values);
@@ -195,6 +197,7 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 		this.number = values.number;
 		this.show = new ShowItem(values.show);
 		this.trakt = values.trakt && new TraktEpisodeItem(values.trakt);
+		this.isAbsolute = values.isAbsolute;
 	}
 
 	save(): EpisodeItemValues {
@@ -205,6 +208,7 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 			number: this.number,
 			show: this.show.save(),
 			trakt: this.trakt?.save(),
+			isAbsolute: this.isAbsolute,
 		};
 	}
 

--- a/src/services/crunchyroll/CrunchyrollApi.ts
+++ b/src/services/crunchyroll/CrunchyrollApi.ts
@@ -1,6 +1,6 @@
 import { ServiceApi, ServiceApiSession } from '@apis/ServiceApi';
 import { Requests, withHeaders } from '@common/Requests';
-import { EpisodeItem, ScrobbleItem } from '@models/Item';
+import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
 import { CrunchyrollService } from '@/crunchyroll/CrunchyrollService';
 import { Utils } from '@common/Utils';
 
@@ -30,6 +30,7 @@ export interface CrunchyrollHistoryItem {
 	fully_watched: boolean;
 	playhead: number;
 	parent_id: string;
+	parent_type?: string;
 	panel: {
 		title: string;
 		episode_metadata: {
@@ -38,7 +39,9 @@ export interface CrunchyrollHistoryItem {
 			season_id: string;
 			episode: string;
 			episode_number?: number;
+			sequence_number?: number;
 			episode_air_date: Date;
+			season_title: string;
 			series_title: string;
 			duration_ms: number;
 		};
@@ -156,31 +159,60 @@ class _CrunchyrollApi extends ServiceApi {
 		return historyItem.id;
 	}
 
+	updateItemFromHistory(item: ScrobbleItem): Promise<void> {
+		// Nothing to update, as Crunchyroll provides all the info in the history endpoint.
+		return Promise.resolve();
+	}
+
 	convertHistoryItems(historyItems: CrunchyrollHistoryItem[]): Promise<ScrobbleItem[]> {
 		const items: ScrobbleItem[] = [];
-		for (const historyItem of historyItems) {
-			const item = new EpisodeItem({
-				id: historyItem.id,
-				serviceId: this.id,
-				title: historyItem.panel.title,
-				// Although we have episode and season info, we omit these,
-				// because the numbers used by Crunchyroll often don't correspond with the Trakt ones.
-				// We are more likely to find a match just using the series name and title.
-				number: 0,
-				season: 0,
-				year: new Date(historyItem.panel.episode_metadata.episode_air_date).getUTCFullYear(),
-				watchedAt: Utils.unix(historyItem.date_played),
-				progress: historyItem.fully_watched
-					? 100
-					: (historyItem.playhead / (historyItem.panel.episode_metadata.duration_ms / 1000)) * 100,
-				show: {
-					id: historyItem.panel.episode_metadata.series_id,
-					serviceId: this.id,
-					title: historyItem.panel.episode_metadata.series_title,
-				},
-			});
+		const dubSubSuffix = / \((?:\w+ )?(?:Dub|Dubbed|Sub|Subbed|Subtitled)\)/;
 
-			items.push(item);
+		for (const historyItem of historyItems) {
+			const metadata = historyItem.panel.episode_metadata;
+			const isMovie =
+				metadata.season_title?.includes('Movie') ||
+				historyItem.panel.title === 'Movie' ||
+				metadata.episode_number?.toString() === 'Movie';
+
+			const title = historyItem.panel.title.replace(dubSubSuffix, '');
+
+			if (isMovie) {
+				const item = new MovieItem({
+					id: historyItem.id,
+					serviceId: this.id,
+					title: title,
+					year: new Date(metadata.episode_air_date).getUTCFullYear(),
+					watchedAt: Utils.unix(historyItem.date_played),
+					progress: historyItem.fully_watched
+						? 100
+						: (historyItem.playhead / (metadata.duration_ms / 1000)) * 100,
+				});
+				items.push(item);
+			} else {
+				const item = new EpisodeItem({
+					id: historyItem.id,
+					serviceId: this.id,
+					title:
+						title.toLowerCase() === 'episode'
+							? `${title} ${metadata.episode || metadata.sequence_number}`
+							: title,
+					number: metadata.episode_number || 0,
+					season: metadata.season_number || 0,
+					isAbsolute: true,
+					year: new Date(metadata.episode_air_date).getUTCFullYear(),
+					watchedAt: Utils.unix(historyItem.date_played),
+					progress: historyItem.fully_watched
+						? 100
+						: (historyItem.playhead / (metadata.duration_ms / 1000)) * 100,
+					show: {
+						id: metadata.series_id,
+						serviceId: this.id,
+						title: metadata.series_title,
+					},
+				});
+				items.push(item);
+			}
 		}
 
 		return Promise.resolve(items);

--- a/src/services/crunchyroll/CrunchyrollApi.ts
+++ b/src/services/crunchyroll/CrunchyrollApi.ts
@@ -122,7 +122,7 @@ class _CrunchyrollApi extends ServiceApi {
 		await this.checkLogin();
 
 		if (!this.nextHistoryUrl && this.session?.accountId) {
-			this.nextHistoryUrl = `${this.HOST_URL}/content/v1/watch-history/${this.session.accountId}?locale=en-US&page=1&page_size=10`;
+			this.nextHistoryUrl = `${this.HOST_URL}/content/v1/watch-history/${this.session.accountId}?locale=en-US&page=1&page_size=20`;
 		}
 
 		// Retrieve the history items
@@ -186,7 +186,7 @@ class _CrunchyrollApi extends ServiceApi {
 					watchedAt: Utils.unix(historyItem.date_played),
 					progress: historyItem.fully_watched
 						? 100
-						: (historyItem.playhead / (metadata.duration_ms / 1000)) * 100,
+						: (historyItem.playhead / metadata.duration_ms) * 100,
 				});
 				items.push(item);
 			} else {
@@ -199,12 +199,11 @@ class _CrunchyrollApi extends ServiceApi {
 							: title,
 					number: metadata.episode_number || 0,
 					season: metadata.season_number || 0,
-					isAbsolute: true,
 					year: new Date(metadata.episode_air_date).getUTCFullYear(),
 					watchedAt: Utils.unix(historyItem.date_played),
 					progress: historyItem.fully_watched
 						? 100
-						: (historyItem.playhead / (metadata.duration_ms / 1000)) * 100,
+						: (historyItem.playhead / metadata.duration_ms) * 100,
 					show: {
 						id: metadata.series_id,
 						serviceId: this.id,


### PR DESCRIPTION
## Summary

This PR enhances episode matching capabilities and improves error handling, particularly for anime content and services using absolute episode numbering.

## Issues Fixed

Fixes #441 - Movies from crunchyroll are not trackable
Fixes #330 - Crunchyroll history sync fails due to title mismatch
Fixes #321 - When episode number does not match, episode name could be used as fallback
Fixes #315 - Crunchyroll sync cannot load history

## Changes

### Core Model Enhancement
- **Add isAbsolute field to EpisodeItem** - Track episodes using absolute numbering (common in anime)

### Error Handling Improvements
- **Add Cloudflare rate limiting detection** - Automatically detect and retry when encountering Cloudflare Error 1015 and other rate limit responses

### TMDB Integration
- **Add TV show search method** - Search for shows with optional year filtering and anime prioritization for Crunchyroll
- **Add episode title search** - Find episodes within a show by matching episode titles

### Episode Search Enhancements
- **Absolute episode number resolution** - Convert absolute episode numbers to season/episode pairs using Trakt season data
- **TMDB fallback mechanism** - When Trakt episode lookup fails, search TMDB for the show and find the episode by title
- **Edge case handling** - Detect new seasons not yet in Trakt database

### Crunchyroll Service Improvements
- **Movie detection** - Distinguish between movies and episodes in Crunchyroll history
- **Enhanced metadata parsing** - Use sequence_number as fallback, strip language suffixes (Dub/Sub)
- **Absolute numbering support** - Mark episodes with isAbsolute flag for proper handling
- **Add updateItemFromHistory() stub** - Resolve missing method implementation error

## Benefits

- ✅ Movies from Crunchyroll are now properly detected and trackable
- ✅ Episode title matching as fallback when season/episode numbers don't align
- ✅ Handles translation mismatches between Crunchyroll and Trakt/TMDB
- ✅ Better matching accuracy for anime content using absolute episode numbering
- ✅ More resilient to API rate limiting and temporary failures
- ✅ Handles edge cases with new seasons and absolute episode numbering
- ✅ Improved movie vs episode detection for streaming services

## Testing

These changes have been tested with Crunchyroll history parsing and various anime titles using absolute episode numbering.

---

*Co-authored-by: damman01 <bigdome91@gmail.com>*