### PR TITLE
Change to D+ history call, fix for HBO Max, New Services for BBC iPlayer (UK) and Channel4 (UK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Never delete the `translations` branch after merging PRs from Crowdin, as Crowdi
 ### Development
 
 1. Create an application in the [Trakt API](https://trakt.tv/oauth/applications/new) (don't forget to check the `/scrobble` permission).
-2. In `Redirect uri:`, put `https://trakt.tv/apps`. If the Trakt authorisation fails. for Chome extensions you can also add the extension ID as the first url e.g. `https://{extension ID}.chromiumapp.org/`.
+2. In `Redirect uri:`, put `https://trakt.tv/apps`. If the Trakt authorisation fails. for Chrome extensions you can also add the extension ID as the first url e.g. `https://{extension ID}.chromiumapp.org/`.
 3. In `Javascript (cors) origins:`, put `moz-extension://` and `chrome-extension://`.
 4. Copy the `.env.example` example file and change the Trakt.tv credentials. Make sure to also set the extension ID to an arbitrary but unique string, otherwise some browser features might not be available to the extension. The "CHROME_EXTENSION_KEY" can remain empty.
 

--- a/README.md
+++ b/README.md
@@ -67,36 +67,38 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 <!-- services-start -->
 <!-- Update this section with `npx trakt-tools dev update-readme` -->
 
-| Streaming Service | Scrobble | Sync | Limitations                      |
-| :---------------: | :------: | :--: | :------------------------------- |
-|   Amazon Prime    |    ✔️    |  ✔️  | Scrobbling only works in English |
-|       AMC+        |    ✔️    |  ❌  | -                                |
-|       Crave       |    ✔️    |  ✔️  | -                                |
-|    Crunchyroll    |    ❌    |  ✔️  | -                                |
-|    discovery+     |    ✔️    |  ✔️  | -                                |
-|      Disney+      |    ✔️    |  ❌  | -                                |
-|        Go3        |    ✔️    |  ❌  | -                                |
-|     GoPlay BE     |    ✔️    |  ❌  | -                                |
-|      HBO Go       |    ✔️    |  ❌  | -                                |
-|      HBO Max      |    ✔️    |  ✔️  | -                                |
-|      Hotstar      |    ✔️    |  ❌  | -                                |
-|      Kijk.nl      |    ✔️    |  ❌  | -                                |
-|       MUBI        |    ✔️    |  ✔️  | -                                |
-|      Netflix      |    ✔️    |  ✔️  | -                                |
-|        NRK        |    ✔️    |  ✔️  | -                                |
-|     Player.pl     |    ✔️    |  ❌  | -                                |
-|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                                |
-|    SkyShowtime    |    ✔️    |  ❌  | -                                |
-|       Star+       |    ✔️    |  ❌  | -                                |
-|    Streamz BE     |    ✔️    |  ❌  | -                                |
-|      Stremio      |    ✔️    |  ❌  | -                                |
-|      Tet TV+      |    ✔️    |  ❌  | -                                |
-|     TV 2 PLAY     |    ✔️    |  ✔️  | -                                |
-|      Viaplay      |    ✔️    |  ✔️  | -                                |
-|       Vidio       |    ✔️    |  ❌  | -                                |
-|     VRTNu BE      |    ✔️    |  ❌  | -                                |
-|     VTMGo BE      |    ✔️    |  ❌  | -                                |
-|    Wakanim.tv     |    ✔️    |  ❌  | -                                |
+| Streaming Service | Scrobble | Sync | Limitations                                                                                                                                              |
+| :---------------: | :------: | :--: | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|   Amazon Prime    |    ✔️    |  ✔️  | - Scrobbling only works in English                                                                                                                       |
+|       AMC+        |    ✔️    |  ❌  | -                                                                                                                                                        |
+|    BBC iPlayer    |    ❌    |  ✔️  | - iPlayer homepage needs opening before use<br>- iPlayer history only retains the last 50 watched shows<br>- iPlayer uses Shadow DOM preventing scrobble |
+|     Channel 4     |    ✔️    |  ✔️  | - Channel4 history only retains the last 50 watched shows                                                                                                |
+|       Crave       |    ✔️    |  ✔️  | -                                                                                                                                                        |
+|    Crunchyroll    |    ❌    |  ✔️  | -                                                                                                                                                        |
+|    discovery+     |    ✔️    |  ✔️  | - Full history loads by show only, D+ removed ability to load several items at once.                                                                     |
+|      Disney+      |    ✔️    |  ❌  | -                                                                                                                                                        |
+|        Go3        |    ✔️    |  ❌  | -                                                                                                                                                        |
+|     GoPlay BE     |    ✔️    |  ❌  | -                                                                                                                                                        |
+|      HBO Go       |    ✔️    |  ❌  | -                                                                                                                                                        |
+|      HBO Max      |    ✔️    |  ✔️  | - Full history loads by show only, HBO Max removed ability to load several items at once.                                                                |
+|      Hotstar      |    ✔️    |  ❌  | -                                                                                                                                                        |
+|      Kijk.nl      |    ✔️    |  ❌  | -                                                                                                                                                        |
+|       MUBI        |    ✔️    |  ✔️  | -                                                                                                                                                        |
+|      Netflix      |    ✔️    |  ✔️  | -                                                                                                                                                        |
+|        NRK        |    ✔️    |  ✔️  | -                                                                                                                                                        |
+|     Player.pl     |    ✔️    |  ❌  | -                                                                                                                                                        |
+|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                                                                                                                                                        |
+|    SkyShowtime    |    ✔️    |  ❌  | -                                                                                                                                                        |
+|       Star+       |    ✔️    |  ❌  | -                                                                                                                                                        |
+|    Streamz BE     |    ✔️    |  ❌  | -                                                                                                                                                        |
+|      stremio      |    ✔️    |  ❌  | -                                                                                                                                                        |
+|      Tet TV+      |    ✔️    |  ❌  | -                                                                                                                                                        |
+|     TV 2 Play     |    ✔️    |  ✔️  | -                                                                                                                                                        |
+|      Viaplay      |    ✔️    |  ✔️  | -                                                                                                                                                        |
+|       Vidio       |    ✔️    |  ❌  | -                                                                                                                                                        |
+|    VRT Max BE     |    ✔️    |  ❌  | -                                                                                                                                                        |
+|     VTMGo BE      |    ✔️    |  ❌  | -                                                                                                                                                        |
+|    Wakanim.tv     |    ✔️    |  ❌  | -                                                                                                                                                        |
 
 <!-- services-end -->
 
@@ -130,7 +132,7 @@ Never delete the `translations` branch after merging PRs from Crowdin, as Crowdi
 ### Development
 
 1. Create an application in the [Trakt API](https://trakt.tv/oauth/applications/new) (don't forget to check the `/scrobble` permission).
-2. In `Redirect uri:`, put `https://trakt.tv/apps`.
+2. In `Redirect uri:`, put `https://trakt.tv/apps`. If the Trakt authorisation fails. for Chome extensions you can also add the extension ID as the first url e.g. `https://{extension ID}.chromiumapp.org/`.
 3. In `Javascript (cors) origins:`, put `moz-extension://` and `chrome-extension://`.
 4. Copy the `.env.example` example file and change the Trakt.tv credentials. Make sure to also set the extension ID to an arbitrary but unique string, otherwise some browser features might not be available to the extension. The "CHROME_EXTENSION_KEY" can remain empty.
 

--- a/src/services/amazon-prime/AmazonPrimeService.ts
+++ b/src/services/amazon-prime/AmazonPrimeService.ts
@@ -16,4 +16,5 @@ export const AmazonPrimeService = new Service({
 	hasSync: true,
 	hasAutoSync: true,
 	loginPage: 'https://www.primevideo.com/settings/watch-history/',
+	limitations: ['Scrobbling only works in English'],
 });

--- a/src/services/bbciplayer/BbciplayerApi.ts
+++ b/src/services/bbciplayer/BbciplayerApi.ts
@@ -1,0 +1,320 @@
+import { Requests } from '@common/Requests';
+import { ServiceApi, ServiceApiSession } from '@apis/ServiceApi';
+import { MovieItem, EpisodeItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
+import { BbciplayerService } from '@/bbciplayer/BbciplayerService';
+import { Utils } from '@common/Utils';
+
+export interface BBCProfileData {
+	profileAdmin: {
+		credential: string;
+		displayName: string;
+		email: string;
+		username: string;
+	};
+	permissions: {
+		create: boolean;
+		switch: boolean;
+	};
+	profiles: any[];
+}
+
+export interface BBCSession extends ServiceApiSession {
+	profileName: string;
+	email: string;
+	username: string;
+}
+
+export interface BBCHistoryItem {
+	id: string;
+	title: string;
+	showTitle: string;
+	season?: number;
+	episode?: number;
+	progress?: number;
+	completed?: boolean;
+	watchedAt?: number;
+}
+
+interface BBCPlay {
+	id: string;
+	action: string; // e.g., 'ended'
+	offset?: number;
+	timestamp?: string | number;
+}
+
+interface BBCEpisodeDetails {
+	id: string;
+	title?: string;
+	original_title?: string;
+	brand_title?: string;
+	slice_id?: string;
+	parent_position?: number;
+	episode_number?: number;
+	versions?: { duration?: { value?: string }; first_broadcast_date_time?: string }[];
+	release_date_time?: string; // keep this
+	release_date?: string; // optional, some endpoints may include this
+	labels?: { category?: string };
+	categories?: string[];
+}
+
+class _BbciplayerApi extends ServiceApi {
+	public session: BBCSession | null = null;
+	public hasReachedHistoryEnd = false;
+	public isActivated = false;
+
+	private BASE_URL = 'https://session.bbc.co.uk';
+	private PROFILE_URL = `${this.BASE_URL}/session/profiles`;
+
+	constructor() {
+		super(BbciplayerService.id);
+	}
+
+	async activate(): Promise<void> {
+		try {
+			const responseText = await Requests.send({ url: this.PROFILE_URL, method: 'GET' });
+			const data = JSON.parse(responseText) as BBCProfileData;
+
+			if (data?.profileAdmin?.displayName) {
+				this.session = {
+					profileName: data.profileAdmin.displayName,
+					email: data.profileAdmin.email,
+					username: data.profileAdmin.username,
+				};
+				this.isActivated = true;
+			} else {
+				this.session = null;
+				this.isActivated = false;
+			}
+		} catch (err) {
+			console.warn('[BBC] Failed to activate session', err);
+			this.session = null;
+			this.isActivated = false;
+		}
+	}
+
+	async checkLogin(): Promise<boolean> {
+		if (!this.isActivated) await this.activate();
+		return !!this.session?.profileName;
+	}
+
+	/** Fetch viewing history using /user/plays */
+	async loadHistoryItems(): Promise<BBCHistoryItem[]> {
+		await this.checkLogin();
+		if (!this.session) throw new Error('Not logged in to BBC iPlayer');
+
+		const history: BBCHistoryItem[] = [];
+		let nextUrl: string | null = 'https://user.ibl.api.bbc.co.uk/ibl/v1/user/plays';
+		this.hasReachedHistoryEnd = false;
+
+		try {
+			// single attempt only
+			const playsResp = await Requests.send({ url: nextUrl, method: 'GET' });
+			const playsData = JSON.parse(playsResp) as { plays: BBCPlay[] };
+			const plays = playsData.plays ?? [];
+			console.log(`[BBC] Found ${plays.length} play entries from ${nextUrl}`);
+
+			for (const play of plays) {
+				try {
+					const [playDetails, epDetails] = await Promise.all([
+						this.fetchPlayDetails(play.id),
+						this.fetchEpisodeDetails(play.id),
+					]);
+
+					if (!epDetails) continue; // epDetails is BBCEpisodeDetails
+
+					const showTitle = epDetails.brand_title ?? epDetails.title ?? 'Unknown';
+					const episodeTitle = epDetails.original_title ?? epDetails.title ?? 'Unknown';
+					const season = parseInt(epDetails.slice_id?.match(/structural-(\d+)-/)?.[1] ?? '1', 10);
+					const episodeNum = epDetails.parent_position ?? 1;
+					const completed = play.action === 'ended';
+					const rawTimestamp =
+						playDetails?.timestamp ??
+						epDetails?.versions?.[0]?.first_broadcast_date_time ??
+						epDetails?.release_date_time ??
+						undefined;
+
+					const watchedAt = rawTimestamp ? Utils.unix(rawTimestamp) : undefined;
+					const duration = this.parseDuration(epDetails.versions?.[0]?.duration?.value);
+					const progress = completed
+						? 100
+						: play.offset !== undefined
+							? Math.min(Math.floor((play.offset / Math.max(duration, 1)) * 100), 99)
+							: 0; // fallback if offset is undefined
+
+					history.push({
+						id: play.id,
+						title: episodeTitle,
+						showTitle,
+						season,
+						episode: episodeNum,
+						progress,
+						completed,
+						watchedAt,
+					});
+				} catch (err) {
+					console.warn('[BBC] Failed processing play', play.id, err);
+				}
+			}
+
+			this.hasReachedHistoryEnd = true;
+			history.sort((a, b) => (b.watchedAt ?? 0) - (a.watchedAt ?? 0));
+			console.log(`[BBC] Total watched episodes: ${history.length}`);
+			return history;
+		} catch (err) {
+			console.warn('[BBC] Failed to load history on first attempt', err);
+			// stop processing entirely
+			this.hasReachedHistoryEnd = true;
+			return [];
+		}
+	}
+
+	private async fetchPlayDetails(id: string): Promise<BBCPlay> {
+		const res = await Requests.send({
+			url: `https://user.ibl.api.bbc.co.uk/ibl/v1/user/plays/${id}`,
+			method: 'GET',
+		});
+		return JSON.parse(res) as BBCPlay;
+	}
+
+	private async fetchEpisodeDetails(id: string): Promise<BBCEpisodeDetails | null> {
+		const res = await Requests.send({
+			url: `https://ibl.api.bbci.co.uk/ibl/v1/episodes/${id}`,
+			method: 'GET',
+		});
+		const ep = JSON.parse(res)?.episodes?.[0];
+		return ep ?? null;
+	}
+
+	private parseDuration(isoDuration: string | undefined): number {
+		if (!isoDuration) return 0;
+		const match = isoDuration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?/);
+		if (!match) return 0;
+		const hours = parseInt(match[1] ?? '0', 10);
+		const minutes = parseInt(match[2] ?? '0', 10);
+		const seconds = parseFloat(match[3] ?? '0');
+		return hours * 3600 + minutes * 60 + seconds;
+	}
+
+	/** Convert ISO timestamp string or number to UNIX seconds */
+	private toUnix(rawTimestamp?: string | number): number {
+		if (!rawTimestamp) return Math.floor(Date.now() / 1000);
+		if (typeof rawTimestamp === 'number') return rawTimestamp; // already UNIX seconds
+		return Math.floor(new Date(rawTimestamp).getTime() / 1000);
+	}
+
+	/** Convert history items to ScrobbleItems for Trakt */
+	async convertHistoryItems(historyItems: BBCHistoryItem[]): Promise<ScrobbleItem[]> {
+		return Promise.all(
+			historyItems.map(async (ep) => {
+				const epDetails = await this.fetchEpisodeDetails(ep.id);
+				if (!epDetails) return null;
+
+				const isFilm =
+					epDetails.labels?.category?.startsWith('Film') || epDetails.categories?.includes('films');
+
+				if (isFilm) {
+					const releaseDateTime = epDetails.release_date_time ?? epDetails.release_date;
+					const year = releaseDateTime ? new Date(releaseDateTime).getUTCFullYear() : undefined;
+
+					return new MovieItem({
+						serviceId: this.id,
+						id: ep.id,
+						title: ep.title ?? epDetails.original_title ?? 'Unknown film',
+						year: year ?? new Date().getUTCFullYear(),
+						watchedAt: this.toUnix(ep.watchedAt),
+						progress: ep.completed ? 100 : (ep.progress ?? 0),
+					});
+				}
+
+				// Normal episode
+				const year = new Date(this.toUnix(ep.watchedAt) * 1000).getUTCFullYear();
+
+				return new EpisodeItem({
+					serviceId: this.id,
+					id: ep.id,
+					title: ep.title,
+					season: ep.season ?? 0,
+					number: ep.episode ?? 0,
+					year,
+					watchedAt: this.toUnix(ep.watchedAt),
+					progress: ep.completed ? 100 : (ep.progress ?? 0),
+					show: { serviceId: this.id, id: ep.showTitle, title: ep.showTitle },
+				});
+			})
+		).then((items) => items.filter(Boolean) as ScrobbleItem[]);
+	}
+
+	/** Update existing ScrobbleItem with history data */
+	updateItemFromHistory(item: ScrobbleItemValues, historyItem: BBCHistoryItem): void {
+		item.progress = historyItem.completed ? 100 : (historyItem.progress ?? 0);
+		if (historyItem.watchedAt !== undefined) {
+			item.watchedAt = this.toUnix(historyItem.watchedAt);
+		}
+	}
+
+	/** Determine if a history item is new compared to last sync */
+	isNewHistoryItem(historyItem: BBCHistoryItem, lastSync: number): boolean {
+		return this.toUnix(historyItem.watchedAt) > lastSync;
+	}
+
+	/** Get unique history item ID */
+	getHistoryItemId(historyItem: BBCHistoryItem): string {
+		return historyItem.id;
+	}
+
+	async getItem(id: string): Promise<ScrobbleItem | null> {
+		if (!this.isActivated) await this.activate();
+		if (!this.session) throw new Error('Invalid session');
+
+		try {
+			const responseText = await Requests.send({
+				url: `https://ibl.api.bbci.co.uk/ibl/v1/episodes/${id}`,
+				method: 'GET',
+			});
+			const data = JSON.parse(responseText)?.episodes?.[0];
+			if (!data) return null;
+
+			const isFilm =
+				data.labels?.category?.startsWith('Film') || data.categories?.includes('films');
+
+			if (isFilm) {
+				// Use release_date_time for MovieItem year
+				const releaseDateTime = data.release_date_time ?? data.release_date;
+				const year = releaseDateTime ? new Date(releaseDateTime).getUTCFullYear() : undefined;
+
+				return new MovieItem({
+					serviceId: this.id,
+					id: data.id,
+					title: data.title ?? data.original_title ?? 'Unknown film',
+					year: year ?? new Date().getUTCFullYear(),
+					watchedAt: year ? this.toUnix(releaseDateTime) : undefined,
+					progress: 100, // BBC doesn’t report partial film progress yet
+				});
+			}
+
+			// Regular series episode
+			const season = data.parent_position ?? 0;
+			const number = data.episode_number ?? 0;
+
+			return new EpisodeItem({
+				serviceId: this.id,
+				id: data.id,
+				title: data.title,
+				season,
+				number,
+				watchedAt: this.toUnix(data.watchedAt),
+				progress: data.watchedAt,
+				show: {
+					serviceId: this.id,
+					title: data.brand_title ?? data.title,
+				},
+			});
+			console.log('[BBC] Fetched item:', id, data);
+		} catch (err) {
+			console.error('[BBC] Failed to fetch item:', err);
+			return null;
+		}
+	}
+}
+
+export const BbciplayerApi = new _BbciplayerApi();

--- a/src/services/bbciplayer/BbciplayerParser.ts
+++ b/src/services/bbciplayer/BbciplayerParser.ts
@@ -1,0 +1,12 @@
+import { BbciplayerApi } from '@/bbciplayer/BbciplayerApi';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+
+class _BbciplayerParser extends ScrobbleParser {
+	constructor() {
+		super(BbciplayerApi, {
+			watchingUrlRegex: /\/iplayer\/episode\/(?<id>b[0-9a-z]+)/,
+		});
+	}
+}
+
+export const BbciplayerParser = new _BbciplayerParser();

--- a/src/services/bbciplayer/BbciplayerService.ts
+++ b/src/services/bbciplayer/BbciplayerService.ts
@@ -1,0 +1,16 @@
+import { Service } from '@models/Service';
+
+export const BbciplayerService = new Service({
+	id: 'bbciplayer',
+	name: 'BBC iPlayer',
+	homePage: 'https://www.bbc.co.uk',
+	hostPatterns: ['*://*.bbc.co.uk/*', '*://*.bbc.com/*'],
+	hasScrobbler: false,
+	hasSync: true,
+	hasAutoSync: true,
+	limitations: [
+		'iPlayer homepage needs opening before use',
+		'iPlayer history only retains the last 50 watched shows',
+		'iPlayer uses Shadow DOM preventing scrobble',
+	],
+});

--- a/src/services/bbciplayer/bbciplayer.ts
+++ b/src/services/bbciplayer/bbciplayer.ts
@@ -1,0 +1,4 @@
+import { init } from '@service';
+import '@/bbciplayer/BbciplayerParser';
+
+void init('bbciplayer');

--- a/src/services/channel4/Channel4Api.ts
+++ b/src/services/channel4/Channel4Api.ts
@@ -1,0 +1,255 @@
+import { ServiceApi } from '@apis/ServiceApi';
+import { Requests } from '@common/Requests';
+import { MovieItem, EpisodeItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
+import { Channel4Service } from '@/channel4/Channel4Service';
+import { Shared } from '@common/Shared';
+
+export interface Channel4Root {
+	history: { availableItems: Channel4HistoryItem[]; unavailableItems: Channel4HistoryItem[] };
+	watching: { availableItems: Channel4HistoryItem[]; unavailableItems: Channel4HistoryItem[] };
+}
+
+export interface Channel4HistoryItem {
+	brand: { title: string; websafeTitle: string; programmeType: string };
+	episode: {
+		seriesNumber: number;
+		episodeNumber: number;
+		programmeId: string;
+		resume: { seconds: number; completed: boolean };
+	};
+}
+
+export interface Channel4VodStream {
+	webSafeBrandTitle: string;
+	transcodeId: string;
+}
+
+class _Channel4Api extends ServiceApi {
+	public session: { profileName: string } | null = null;
+	public hasReachedHistoryEnd = false;
+	public isActivated = false;
+
+	private BASE_URL = 'https://www.channel4.com';
+	private PROFILE_URL = `${this.BASE_URL}/identity/whoami`;
+	private MYFOUR_URL = `${this.BASE_URL}/my4/api/v1/myfour.json`;
+
+	private programmeCache = new Map<string, Channel4VodStream>();
+
+	constructor() {
+		super(Channel4Service.id);
+	}
+
+	async activate(): Promise<void> {
+		try {
+			const res = await Requests.send({ url: this.PROFILE_URL, method: 'GET' });
+			const profile = JSON.parse(res);
+			this.session = { profileName: profile.identity?.displayName };
+			this.isActivated = true;
+			console.log('[Channel4] Activated session for', this.session.profileName);
+		} catch (err) {
+			console.warn('[Channel4] Failed to activate session', err);
+			this.session = null;
+			this.isActivated = false;
+		}
+	}
+
+	async checkLogin(): Promise<boolean> {
+		if (!this.isActivated) await this.activate();
+		return !!this.session?.profileName;
+	}
+
+	async loadHistoryItems(cancelKey = 'default'): Promise<Channel4HistoryItem[]> {
+		await this.checkLogin();
+		if (!this.session) {
+			console.log('[Channel4] loadHistoryItems(): No session');
+			return [];
+		}
+
+		try {
+			const responseText = await Requests.send({ url: this.MYFOUR_URL, method: 'GET', cancelKey });
+			const responseJson = JSON.parse(responseText) as Channel4Root;
+
+			const responseItems: Channel4HistoryItem[] = [];
+			(['availableItems'] as const).forEach((key) => {
+				const watchingItems = responseJson.watching?.[key] ?? [];
+				const historyItems = responseJson.history?.[key] ?? [];
+				if (Array.isArray(watchingItems)) responseItems.push(...watchingItems);
+				if (Array.isArray(historyItems)) responseItems.push(...historyItems);
+			});
+
+			this.hasReachedHistoryEnd = true;
+			console.log(`[Channel4] loadHistoryItems() fetched ${responseItems.length} items`);
+			return responseItems;
+		} catch (err) {
+			console.warn('[Channel4] Failed to load My4 history', err);
+			this.hasReachedHistoryEnd = true;
+			return [];
+		}
+	}
+
+	private async getAssetId(programmeId: string): Promise<Channel4VodStream | null> {
+		if (this.programmeCache.has(programmeId)) return this.programmeCache.get(programmeId)!;
+
+		try {
+			const res = await Requests.send({
+				url: `${this.BASE_URL}/vod/stream/${programmeId}`,
+				method: 'GET',
+			});
+			const data = JSON.parse(res);
+			const meta: Channel4VodStream = {
+				webSafeBrandTitle: data.webSafeBrandTitle,
+				transcodeId: data.transcodeId,
+			};
+			this.programmeCache.set(programmeId, meta);
+			return meta;
+		} catch (err) {
+			console.warn(`[Channel4] Failed to fetch stream meta for ${programmeId}`, err);
+			return null;
+		}
+	}
+
+	private async getAssetData(webSafeBrandTitle: string, transcodeId: string): Promise<any | null> {
+		try {
+			const res = await Requests.send({
+				url: `${this.BASE_URL}/player/${webSafeBrandTitle}/asset/${transcodeId}?json=true`,
+				method: 'GET',
+			});
+			const data = JSON.parse(res);
+
+			const asset = data.asset ?? null;
+			const episodeData = data.actions?.[0]?.playNextEpisode ?? null;
+
+			if (!asset) return null;
+
+			return {
+				...asset,
+				summary: episodeData?.summary,
+				synopsis: episodeData?.synopsis,
+				shortSynopsis: episodeData?.shortSynopsis,
+				secondarySynopsis: episodeData?.secondarySynopsis,
+				secondaryShortSynopsis: episodeData?.secondaryShortSynopsis,
+			};
+		} catch (err) {
+			console.warn(`[Channel4] Failed to fetch asset for ${webSafeBrandTitle}/${transcodeId}`, err);
+			return null;
+		}
+	}
+
+	async convertHistoryItems(items: Channel4HistoryItem[]): Promise<ScrobbleItem[]> {
+		console.log(`[Channel4] convertHistoryItems(): processing ${items.length} items`);
+
+		const processed = await Promise.all(
+			items.map(async (item) => {
+				const programmeId = item.episode?.programmeId;
+				if (!programmeId) return null;
+
+				const scrobbleItem = await this.getItem(programmeId, item);
+				return scrobbleItem;
+			})
+		);
+
+		const results = processed.filter((i): i is ScrobbleItem => !!i);
+		results.sort((a, b) => (!a.watchedAt ? 1 : !b.watchedAt ? -1 : b.watchedAt - a.watchedAt));
+
+		console.log('[Channel4] convertHistoryItems() finished:', {
+			count: results.length,
+			sample: results
+				.slice(0, 5)
+				.map((i) => ({ id: i.id, title: i.title, watchedAt: i.watchedAt })),
+		});
+
+		return results;
+	}
+
+	getHistoryItemId(item: Channel4HistoryItem): string {
+		return item.episode?.programmeId ?? '';
+	}
+
+	isNewHistoryItem(historyItem: Channel4HistoryItem, lastSync: number): boolean {
+		const watchedAt = historyItem.episode?.resume?.completed
+			? Math.floor(Date.now() / 1000)
+			: historyItem.episode?.resume?.seconds
+				? Math.floor(Date.now() / 1000)
+				: undefined;
+		return watchedAt ? watchedAt > lastSync : false;
+	}
+
+	updateItemFromHistory(
+		item: ScrobbleItemValues,
+		historyItem: Channel4HistoryItem,
+		assetResumeTimeStamp?: number,
+		assetDuration?: number
+	): void {
+		const completed = historyItem.episode?.resume?.completed ?? false;
+		const secondsWatched = historyItem.episode?.resume?.seconds ?? 0;
+		const duration = assetDuration ?? 1;
+		item.progress = completed ? 100 : Math.min((secondsWatched / duration) * 100, 99);
+		const watchedAt = assetResumeTimeStamp ? Math.floor(assetResumeTimeStamp / 1000) : undefined;
+		if (watchedAt !== undefined) item.watchedAt = watchedAt;
+	}
+
+	async getItem(
+		programmeId: string,
+		historyItem?: Channel4HistoryItem
+	): Promise<ScrobbleItem | null> {
+		if (!this.isActivated) await this.activate();
+		if (!this.session) throw new Error('Invalid session');
+
+		try {
+			const meta = await this.getAssetId(programmeId);
+			if (!meta) return null;
+
+			const asset = await this.getAssetData(meta.webSafeBrandTitle, meta.transcodeId);
+			if (!asset) return null;
+
+			const completed = historyItem?.episode?.resume?.completed ?? false;
+			const secondsWatched = historyItem?.episode?.resume?.seconds ?? asset.resumeSeconds ?? 0;
+
+			const progress = completed
+				? 100
+				: Math.min((secondsWatched / (asset.assetDuration ?? 1)) * 100, 99);
+
+			const watchedAt = asset.resumeTimeStamp
+				? Math.floor(Number(asset.resumeTimeStamp) / 1000)
+				: undefined;
+
+			const isFilm = asset.programmeType === 'FM' || historyItem?.brand?.programmeType === 'FM';
+
+			const yearMatch =
+				asset.summary?.match(/^\((\d{4})\)/) ||
+				asset.synopsis?.match(/^\((\d{4})\)/) ||
+				asset.shortSynopsis?.match(/^\((\d{4})\)/) ||
+				asset.secondarySynopsis?.match(/^\((\d{4})\)/) ||
+				asset.secondaryShortSynopsis?.match(/^\((\d{4})\)/);
+
+			const year = yearMatch ? parseInt(yearMatch[1], 10) : undefined;
+
+			if (isFilm) {
+				return new MovieItem({
+					serviceId: this.id,
+					id: asset.assetId,
+					title: asset.brandTitle,
+					year,
+					watchedAt,
+					progress,
+				});
+			}
+
+			return new EpisodeItem({
+				serviceId: this.id,
+				id: asset.assetId,
+				title: asset.episodeSecondaryTitle || asset.episodeTitle,
+				season: asset.seriesNumber ?? 0,
+				number: asset.episodeNumber ?? 0,
+				watchedAt,
+				progress,
+				show: { serviceId: this.id, title: asset.brandTitle },
+			});
+		} catch (err) {
+			if (Shared.errors.validate(err)) Shared.errors.error('Failed to get Channel4 item.', err);
+			return null;
+		}
+	}
+}
+
+export const Channel4Api = new _Channel4Api();

--- a/src/services/channel4/Channel4Parser.ts
+++ b/src/services/channel4/Channel4Parser.ts
@@ -1,0 +1,12 @@
+import { Channel4Api } from '@/channel4/Channel4Api';
+import { ScrobbleParser } from '@common/ScrobbleParser';
+
+class _Channel4Parser extends ScrobbleParser {
+	constructor() {
+		super(Channel4Api, {
+			watchingUrlRegex: /programmes\/(?<brand>[\w-]+)\/on-demand\/(?<id>[\w-]+)/,
+		});
+	}
+}
+
+export const Channel4Parser = new _Channel4Parser();

--- a/src/services/channel4/Channel4Service.ts
+++ b/src/services/channel4/Channel4Service.ts
@@ -1,0 +1,12 @@
+import { Service } from '@models/Service';
+
+export const Channel4Service = new Service({
+	id: 'channel4',
+	name: 'Channel 4',
+	homePage: 'https://www.channel4.com',
+	hostPatterns: ['*://*.channel4.com/*'],
+	hasScrobbler: true,
+	hasSync: true,
+	hasAutoSync: true,
+	limitations: ['Channel4 history only retains the last 50 watched shows'],
+});

--- a/src/services/channel4/channel4.ts
+++ b/src/services/channel4/channel4.ts
@@ -1,0 +1,4 @@
+import { init } from '@service';
+import '@/channel4/Channel4Parser';
+
+void init('channel4');

--- a/src/services/discoveryplus/DiscoveryplusApi.ts
+++ b/src/services/discoveryplus/DiscoveryplusApi.ts
@@ -60,25 +60,24 @@ class _DiscoveryplusApi extends ServiceApi {
 		super(DiscoveryplusService.id);
 	}
 
-	/** Initialize the API URL using cached routing or bootstrap */
+	/* ---------------- API ROUTING ---------------- */
+
 	private async initApiUrl(): Promise<void> {
 		const env = 'prd';
 		const domain = 'api.discoveryplus.com';
 		const cacheKey = 'servicesData';
-		const ttl = 7 * 24 * 60 * 60 * 1000; // 7 days
+		const ttl = 7 * 24 * 60 * 60 * 1000;
 
-		// Fetch cache wrapper
 		const cacheItem: CacheItem<'servicesData'> | undefined = await Cache.get(cacheKey);
-
-		// Read cached routing for this service
 		const cached = cacheItem?.get(this.id) as CachedRouting | undefined;
+
 		if (cached?.routing && Date.now() - cached.timestamp < ttl) {
 			this.applyRouting(cached.routing);
 			return;
 		}
 
-		// Fetch bootstrap routing from Discovery+
 		const bootstrapUrl = `https://default.any-any.${env}.${domain}/session-context/headwaiter/v1/bootstrap`;
+
 		const responseText = await Requests.send({
 			url: bootstrapUrl,
 			method: 'POST',
@@ -90,26 +89,23 @@ class _DiscoveryplusApi extends ServiceApi {
 		});
 
 		const bootstrap = JSON.parse(responseText) as { routing?: DiscoveryplusRouting };
-		if (!bootstrap.routing) throw new Error('Invalid bootstrap: missing routing');
+		if (!bootstrap.routing) throw new Error('Invalid bootstrap');
 
 		this.applyRouting(bootstrap.routing);
-
-		// Save routing back to cache
 		cacheItem?.set(this.id, { routing: bootstrap.routing, timestamp: Date.now() });
 	}
 
-	/** Apply routing to API URLs */
 	private applyRouting(routing: DiscoveryplusRouting): void {
 		this.API_URL = `https://default.${routing.tenant}-${routing.homeMarket}.${routing.env}.${routing.domain}`;
 		this.PROFILE_URL = `${this.API_URL}/users/me/profiles/selected`;
 		this.ALLSHOWS_URL = `${this.API_URL}/cms/routes/my-stuff?include=default&decorators=viewingHistory,isFavorite,contentAction,badges&page[items.size]=100`;
 	}
 
-	/** Activate service session */
+	/* ---------------- SESSION ---------------- */
+
 	async activate(): Promise<void> {
 		try {
 			await this.initApiUrl();
-
 			const response = await Requests.send({ url: this.PROFILE_URL, method: 'GET' });
 			const profileData = JSON.parse(response) as DiscoveryplusProfileData;
 
@@ -121,15 +117,16 @@ class _DiscoveryplusApi extends ServiceApi {
 		}
 	}
 
-	/** Check if user is logged in */
 	async checkLogin(): Promise<boolean> {
 		if (!this.isActivated) await this.activate();
 		return !!this.session?.profileName;
 	}
 
-	/** Fetch all series show IDs and populate showNameMap */
+	/* ---------------- SHOW LIST ---------------- */
+
 	private async fetchSeriesShowIds(): Promise<string[]> {
 		const responseText = await Requests.send({ url: this.ALLSHOWS_URL, method: 'GET' });
+
 		const allShowsResponse = JSON.parse(responseText) as {
 			included?: Array<{ id: string; attributes?: { showType?: string; name?: string } }>;
 		};
@@ -138,16 +135,19 @@ class _DiscoveryplusApi extends ServiceApi {
 			allShowsResponse.included
 				?.filter((item) => item.attributes?.showType === 'SERIES')
 				.map((item) => {
-					if (item.attributes?.name) this.showNameMap[item.id] = item.attributes.name;
+					if (item.attributes?.name) {
+						this.showNameMap[item.id] = item.attributes.name;
+					}
 					return item.id;
 				}) ?? [];
 
 		return showIds;
 	}
 
-	/** Load the next page of history items */
+	/* ---------------- HISTORY PAGING ---------------- */
+
 	private async loadNextHistoryPage(): Promise<DiscoveryplusHistoryItem[]> {
-		if (!this.showIdsParam) throw new Error('No show IDs set for history request');
+		if (!this.showIdsParam) throw new Error('No show IDs set');
 
 		const params = new URLSearchParams({
 			decorators: 'viewingHistory',
@@ -160,7 +160,11 @@ class _DiscoveryplusApi extends ServiceApi {
 		const historyApiUrl = new URL(`${this.API_URL}/content/videos`);
 		historyApiUrl.search = params.toString();
 
-		const responseText = await Requests.send({ url: historyApiUrl.toString(), method: 'GET' });
+		const responseText = await Requests.send({
+			url: historyApiUrl.toString(),
+			method: 'GET',
+		});
+
 		const responseJson = JSON.parse(responseText) as {
 			data: DiscoveryplusHistoryItem[];
 			meta: { totalPages: number };
@@ -171,6 +175,7 @@ class _DiscoveryplusApi extends ServiceApi {
 
 		this.hasReachedHistoryEnd = this.currentHistoryPage >= totalPages;
 		this.currentHistoryPage++;
+
 		return historyItems;
 	}
 
@@ -180,30 +185,45 @@ class _DiscoveryplusApi extends ServiceApi {
 		this.hasReachedHistoryEnd = false;
 
 		const items: DiscoveryplusHistoryItem[] = [];
+
 		while (!this.hasReachedHistoryEnd) {
 			const pageItems = await this.loadNextHistoryPage();
 			items.push(...pageItems);
 		}
+
 		return items;
 	}
 
-	/** Load all history items */
-	async loadHistoryItems(_cancelKey = 'default'): Promise<DiscoveryplusHistoryItem[]> {
+	/* ---------------- LOAD ALL HISTORY ---------------- */
+
+	async loadHistoryItems(): Promise<DiscoveryplusHistoryItem[]> {
 		if (!this.isActivated) await this.activate();
 		if (!this.session) throw new Error('Invalid API session');
 
 		const showIds = await this.fetchSeriesShowIds();
 		if (!showIds.length) return [];
 
-		// Load all shows in parallel
-		const results = await Promise.all(showIds.map((id) => this.loadHistoryForShow(id)));
+		const allHistoryItems: DiscoveryplusHistoryItem[] = [];
 
-		const allHistoryItems = results.flat();
+		// Limited concurrency batching
+		const concurrency = 5;
 
+		for (let i = 0; i < showIds.length; i += concurrency) {
+			const batch = showIds.slice(i, i + concurrency);
+
+			const results = await Promise.all(batch.map((id) => this.loadHistoryForShow(id)));
+
+			for (const items of results) {
+				allHistoryItems.push(...items);
+			}
+		}
+
+		// Filter watched episodes
 		const viewedEpisodes = allHistoryItems.filter(
 			(i) => i.attributes.videoType === 'EPISODE' && i.attributes.viewingHistory.viewed
 		);
 
+		// Sort entire combined list by watched date
 		viewedEpisodes.sort((a, b) => {
 			const t1 = Utils.unix(
 				a.attributes.viewingHistory?.lastReportedTimestamp ?? a.attributes.airDate
@@ -217,47 +237,49 @@ class _DiscoveryplusApi extends ServiceApi {
 		return viewedEpisodes;
 	}
 
-	/** Convert history items to ScrobbleItem array */
+	/* ---------------- CONVERT TO SCROBBLES ---------------- */
+
 	async convertHistoryItems(historyItems: DiscoveryplusHistoryItem[]): Promise<ScrobbleItem[]> {
 		const items: ScrobbleItem[] = [];
 
 		for (const ep of historyItems) {
 			const showId = ep.relationships.show.data.id ?? '';
 			const showName = this.showNameMap[showId] ?? 'Unknown Show';
+
 			const watchedAt = Utils.unix(
 				ep.attributes.viewingHistory?.lastReportedTimestamp ?? ep.attributes.airDate
 			);
 
-			// Simulate async processing if needed (or replace with actual async calls)
 			items.push(
-				await Promise.resolve(
-					new EpisodeItem({
+				new EpisodeItem({
+					serviceId: this.id,
+					id: ep.id,
+					title: ep.attributes.name,
+					season: ep.attributes.seasonNumber,
+					number: ep.attributes.episodeNumber,
+					year: new Date(ep.attributes.airDate ?? ep.attributes.firstAvailableDate).getFullYear(),
+					watchedAt,
+					progress: ep.attributes.viewingHistory?.completed ? 100 : 0,
+					show: {
 						serviceId: this.id,
-						id: ep.id,
-						title: ep.attributes.name,
-						season: ep.attributes.seasonNumber,
-						number: ep.attributes.episodeNumber,
-						year: new Date(ep.attributes.airDate ?? ep.attributes.firstAvailableDate).getFullYear(),
-						watchedAt,
-						progress: ep.attributes.viewingHistory?.completed ? 100 : 0,
-						show: { serviceId: this.id, id: showId, title: showName },
-					})
-				)
+						id: showId,
+						title: showName,
+					},
+				})
 			);
 		}
 
 		return items;
 	}
 
-	/** Update existing item from history */
 	updateItemFromHistory(item: ScrobbleItemValues, historyItem: DiscoveryplusHistoryItem): void {
 		item.watchedAt = Utils.unix(
 			historyItem.attributes.viewingHistory?.lastReportedTimestamp ?? historyItem.attributes.airDate
 		);
+
 		item.progress = historyItem.attributes.viewingHistory?.completed ? 100 : 0;
 	}
 
-	/** Check if history item is new */
 	isNewHistoryItem(historyItem: DiscoveryplusHistoryItem, lastSync: number): boolean {
 		return (
 			Utils.unix(
@@ -267,14 +289,13 @@ class _DiscoveryplusApi extends ServiceApi {
 		);
 	}
 
-	/** Get unique history item ID */
 	getHistoryItemId(historyItem: DiscoveryplusHistoryItem): string {
 		return historyItem.id;
 	}
 
-	/** Get a single item by ID */
 	async getItem(id: string): Promise<ScrobbleItem | null> {
 		const allItems = await this.convertHistoryItems(await this.loadHistoryItems());
+
 		return allItems.find((i) => i.id === id) ?? null;
 	}
 }

--- a/src/services/discoveryplus/DiscoveryplusApi.ts
+++ b/src/services/discoveryplus/DiscoveryplusApi.ts
@@ -174,6 +174,19 @@ class _DiscoveryplusApi extends ServiceApi {
 		return historyItems;
 	}
 
+	async loadHistoryForShow(showId: string): Promise<DiscoveryplusHistoryItem[]> {
+		this.showIdsParam = showId;
+		this.currentHistoryPage = 1;
+		this.hasReachedHistoryEnd = false;
+
+		const items: DiscoveryplusHistoryItem[] = [];
+		while (!this.hasReachedHistoryEnd) {
+			const pageItems = await this.loadNextHistoryPage();
+			items.push(...pageItems);
+		}
+		return items;
+	}
+
 	/** Load all history items */
 	async loadHistoryItems(_cancelKey = 'default'): Promise<DiscoveryplusHistoryItem[]> {
 		if (!this.isActivated) await this.activate();
@@ -182,15 +195,10 @@ class _DiscoveryplusApi extends ServiceApi {
 		const showIds = await this.fetchSeriesShowIds();
 		if (!showIds.length) return [];
 
-		this.showIdsParam = showIds.join(',');
-		this.currentHistoryPage = 1;
-		this.hasReachedHistoryEnd = false;
+		// Load all shows in parallel
+		const results = await Promise.all(showIds.map((id) => this.loadHistoryForShow(id)));
 
-		const allHistoryItems: DiscoveryplusHistoryItem[] = [];
-		while (!this.hasReachedHistoryEnd) {
-			const pageItems = await this.loadNextHistoryPage();
-			allHistoryItems.push(...pageItems);
-		}
+		const allHistoryItems = results.flat();
 
 		const viewedEpisodes = allHistoryItems.filter(
 			(i) => i.attributes.videoType === 'EPISODE' && i.attributes.viewingHistory.viewed

--- a/src/services/discoveryplus/DiscoveryplusService.ts
+++ b/src/services/discoveryplus/DiscoveryplusService.ts
@@ -7,5 +7,8 @@ export const DiscoveryplusService = new Service({
 	hostPatterns: ['*://*.discoveryplus.com/*'],
 	hasScrobbler: true,
 	hasSync: true,
-	hasAutoSync: false,
+	hasAutoSync: true,
+	limitations: [
+		'Full history loads by show only, D+ removed ability to load several items at once.',
+	],
 });

--- a/src/services/hbo-max/HboMaxApi.ts
+++ b/src/services/hbo-max/HboMaxApi.ts
@@ -60,25 +60,24 @@ class _HbomaxApi extends ServiceApi {
 		super(HboMaxService.id);
 	}
 
-	/** Initialize the API URL using cached routing or bootstrap */
+	/* ---------------- API ROUTING ---------------- */
+
 	private async initApiUrl(): Promise<void> {
 		const env = 'prd';
 		const domain = 'api.hbomax.com';
 		const cacheKey = 'servicesData';
-		const ttl = 7 * 24 * 60 * 60 * 1000; // 7 days
+		const ttl = 7 * 24 * 60 * 60 * 1000;
 
-		// Fetch cache wrapper
 		const cacheItem: CacheItem<'servicesData'> | undefined = await Cache.get(cacheKey);
-
-		// Read cached routing for this service
 		const cached = cacheItem?.get(this.id) as CachedRouting | undefined;
+
 		if (cached?.routing && Date.now() - cached.timestamp < ttl) {
 			this.applyRouting(cached.routing);
 			return;
 		}
 
-		// Fetch bootstrap routing from Discovery+
 		const bootstrapUrl = `https://default.any-any.${env}.${domain}/session-context/headwaiter/v1/bootstrap`;
+
 		const responseText = await Requests.send({
 			url: bootstrapUrl,
 			method: 'POST',
@@ -90,26 +89,23 @@ class _HbomaxApi extends ServiceApi {
 		});
 
 		const bootstrap = JSON.parse(responseText) as { routing?: HbomaxRouting };
-		if (!bootstrap.routing) throw new Error('Invalid bootstrap: missing routing');
+		if (!bootstrap.routing) throw new Error('Invalid bootstrap');
 
 		this.applyRouting(bootstrap.routing);
-
-		// Save routing back to cache
 		cacheItem?.set(this.id, { routing: bootstrap.routing, timestamp: Date.now() });
 	}
 
-	/** Apply routing to API URLs */
 	private applyRouting(routing: HbomaxRouting): void {
 		this.API_URL = `https://default.${routing.tenant}-${routing.homeMarket}.${routing.env}.${routing.domain}`;
 		this.PROFILE_URL = `${this.API_URL}/users/me/profiles/selected`;
 		this.ALLSHOWS_URL = `${this.API_URL}/cms/routes/my-stuff?include=default&decorators=viewingHistory,isFavorite,contentAction,badges&page[items.size]=100`;
 	}
 
-	/** Activate service session */
+	/* ---------------- SESSION ---------------- */
+
 	async activate(): Promise<void> {
 		try {
 			await this.initApiUrl();
-
 			const response = await Requests.send({ url: this.PROFILE_URL, method: 'GET' });
 			const profileData = JSON.parse(response) as HbomaxProfileData;
 
@@ -121,15 +117,16 @@ class _HbomaxApi extends ServiceApi {
 		}
 	}
 
-	/** Check if user is logged in */
 	async checkLogin(): Promise<boolean> {
 		if (!this.isActivated) await this.activate();
 		return !!this.session?.profileName;
 	}
 
-	/** Fetch all series show IDs and populate showNameMap */
+	/* ---------------- SHOW LIST ---------------- */
+
 	private async fetchSeriesShowIds(): Promise<string[]> {
 		const responseText = await Requests.send({ url: this.ALLSHOWS_URL, method: 'GET' });
+
 		const allShowsResponse = JSON.parse(responseText) as {
 			included?: Array<{ id: string; attributes?: { showType?: string; name?: string } }>;
 		};
@@ -138,16 +135,19 @@ class _HbomaxApi extends ServiceApi {
 			allShowsResponse.included
 				?.filter((item) => item.attributes?.showType === 'SERIES')
 				.map((item) => {
-					if (item.attributes?.name) this.showNameMap[item.id] = item.attributes.name;
+					if (item.attributes?.name) {
+						this.showNameMap[item.id] = item.attributes.name;
+					}
 					return item.id;
 				}) ?? [];
 
 		return showIds;
 	}
 
-	/** Load the next page of history items */
+	/* ---------------- HISTORY PAGING ---------------- */
+
 	private async loadNextHistoryPage(): Promise<HbomaxHistoryItem[]> {
-		if (!this.showIdsParam) throw new Error('No show IDs set for history request');
+		if (!this.showIdsParam) throw new Error('No show IDs set');
 
 		const params = new URLSearchParams({
 			decorators: 'viewingHistory',
@@ -160,7 +160,11 @@ class _HbomaxApi extends ServiceApi {
 		const historyApiUrl = new URL(`${this.API_URL}/content/videos`);
 		historyApiUrl.search = params.toString();
 
-		const responseText = await Requests.send({ url: historyApiUrl.toString(), method: 'GET' });
+		const responseText = await Requests.send({
+			url: historyApiUrl.toString(),
+			method: 'GET',
+		});
+
 		const responseJson = JSON.parse(responseText) as {
 			data: HbomaxHistoryItem[];
 			meta: { totalPages: number };
@@ -171,6 +175,7 @@ class _HbomaxApi extends ServiceApi {
 
 		this.hasReachedHistoryEnd = this.currentHistoryPage >= totalPages;
 		this.currentHistoryPage++;
+
 		return historyItems;
 	}
 
@@ -180,25 +185,36 @@ class _HbomaxApi extends ServiceApi {
 		this.hasReachedHistoryEnd = false;
 
 		const items: HbomaxHistoryItem[] = [];
+
 		while (!this.hasReachedHistoryEnd) {
 			const pageItems = await this.loadNextHistoryPage();
 			items.push(...pageItems);
 		}
+
 		return items;
 	}
 
-	/** Load all history items */
-	async loadHistoryItems(_cancelKey = 'default'): Promise<HbomaxHistoryItem[]> {
+	/* ---------------- LOAD ALL HISTORY ---------------- */
+
+	async loadHistoryItems(): Promise<HbomaxHistoryItem[]> {
 		if (!this.isActivated) await this.activate();
 		if (!this.session) throw new Error('Invalid API session');
 
 		const showIds = await this.fetchSeriesShowIds();
 		if (!showIds.length) return [];
 
-		// Load all shows in parallel
-		const results = await Promise.all(showIds.map((id) => this.loadHistoryForShow(id)));
+		const allHistoryItems: HbomaxHistoryItem[] = [];
+		const concurrency = 5;
 
-		const allHistoryItems = results.flat();
+		for (let i = 0; i < showIds.length; i += concurrency) {
+			const batch = showIds.slice(i, i + concurrency);
+
+			const results = await Promise.all(batch.map((id) => this.loadHistoryForShow(id)));
+
+			for (const items of results) {
+				allHistoryItems.push(...items);
+			}
+		}
 
 		const viewedEpisodes = allHistoryItems.filter(
 			(i) => i.attributes.videoType === 'EPISODE' && i.attributes.viewingHistory.viewed
@@ -217,47 +233,49 @@ class _HbomaxApi extends ServiceApi {
 		return viewedEpisodes;
 	}
 
-	/** Convert history items to ScrobbleItem array */
+	/* ---------------- CONVERT ---------------- */
+
 	async convertHistoryItems(historyItems: HbomaxHistoryItem[]): Promise<ScrobbleItem[]> {
 		const items: ScrobbleItem[] = [];
 
 		for (const ep of historyItems) {
 			const showId = ep.relationships.show.data.id ?? '';
 			const showName = this.showNameMap[showId] ?? 'Unknown Show';
+
 			const watchedAt = Utils.unix(
 				ep.attributes.viewingHistory?.lastReportedTimestamp ?? ep.attributes.airDate
 			);
 
-			// Simulate async processing if needed (or replace with actual async calls)
 			items.push(
-				await Promise.resolve(
-					new EpisodeItem({
+				new EpisodeItem({
+					serviceId: this.id,
+					id: ep.id,
+					title: ep.attributes.name,
+					season: ep.attributes.seasonNumber,
+					number: ep.attributes.episodeNumber,
+					year: new Date(ep.attributes.airDate ?? ep.attributes.firstAvailableDate).getFullYear(),
+					watchedAt,
+					progress: ep.attributes.viewingHistory?.completed ? 100 : 0,
+					show: {
 						serviceId: this.id,
-						id: ep.id,
-						title: ep.attributes.name,
-						season: ep.attributes.seasonNumber,
-						number: ep.attributes.episodeNumber,
-						year: new Date(ep.attributes.airDate ?? ep.attributes.firstAvailableDate).getFullYear(),
-						watchedAt,
-						progress: ep.attributes.viewingHistory?.completed ? 100 : 0,
-						show: { serviceId: this.id, id: showId, title: showName },
-					})
-				)
+						id: showId,
+						title: showName,
+					},
+				})
 			);
 		}
 
 		return items;
 	}
 
-	/** Update existing item from history */
 	updateItemFromHistory(item: ScrobbleItemValues, historyItem: HbomaxHistoryItem): void {
 		item.watchedAt = Utils.unix(
 			historyItem.attributes.viewingHistory?.lastReportedTimestamp ?? historyItem.attributes.airDate
 		);
+
 		item.progress = historyItem.attributes.viewingHistory?.completed ? 100 : 0;
 	}
 
-	/** Check if history item is new */
 	isNewHistoryItem(historyItem: HbomaxHistoryItem, lastSync: number): boolean {
 		return (
 			Utils.unix(
@@ -267,14 +285,13 @@ class _HbomaxApi extends ServiceApi {
 		);
 	}
 
-	/** Get unique history item ID */
 	getHistoryItemId(historyItem: HbomaxHistoryItem): string {
 		return historyItem.id;
 	}
 
-	/** Get a single item by ID */
 	async getItem(id: string): Promise<ScrobbleItem | null> {
 		const allItems = await this.convertHistoryItems(await this.loadHistoryItems());
+
 		return allItems.find((i) => i.id === id) ?? null;
 	}
 }

--- a/src/services/hbo-max/HboMaxApi.ts
+++ b/src/services/hbo-max/HboMaxApi.ts
@@ -1,465 +1,282 @@
-import { HboMaxService } from '@/hbo-max/HboMaxService';
+import { Requests } from '@common/Requests';
 import { ServiceApi, ServiceApiSession } from '@apis/ServiceApi';
-import { Cache } from '@common/Cache';
-import { Requests, withHeaders } from '@common/Requests';
-import { ScriptInjector } from '@common/ScriptInjector';
-import { Shared } from '@common/Shared';
+import { EpisodeItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
 import { Utils } from '@common/Utils';
-import { EpisodeItem, MovieItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
+import { Cache, CacheItem } from '@common/Cache';
+import { HboMaxService } from '@/hbo-max/HboMaxService';
 
-export interface HboMaxAuthObj {
-	access_token: string;
-	refresh_token: string;
-
-	/** In milliseconds */
-	expires_on: number;
+export interface HbomaxSession extends ServiceApiSession {
+	profileName: string;
 }
 
-export interface HboMaxSession extends ServiceApiSession, HboMaxData {}
-
-export interface HboMaxData {
-	subdomain: string;
-	auth: {
-		accessToken: string;
-		refreshToken: string;
-
-		/** A UNIX timestamp in seconds */
-		expiresAt: number;
-	};
-	deviceSerialNumber: string;
-}
-
-export interface HboMaxProfile {
-	profileId: string;
-	name: string;
-	isMe: boolean;
-}
-
-export interface HboMaxHistoryItem {
+export interface HbomaxHistoryItem {
 	id: string;
-	progress: number;
-	watchedAt: number;
-}
-
-export type HboMaxItemMetadata = HboMaxEpisodeMetadata | HboMaxMovieMetadata;
-
-export interface HboMaxEpisodeMetadata {
-	titles: {
-		full: string;
+	attributes: {
+		seasonNumber: number;
+		episodeNumber: number;
+		name: string;
+		videoType: string;
+		airDate: string;
+		firstAvailableDate: string;
+		viewingHistory: {
+			viewed: boolean;
+			completed?: boolean;
+			lastReportedTimestamp?: string;
+		};
 	};
-	releaseYear: number;
-	seriesTitles: {
-		full: string;
-	};
-	numberInSeason: number;
-	seasonNumber: number;
-	references: {
-		/** Format: urn:hbo:series:XXXXXXXXXXXXXXXXXXXX */
-		series: string;
-	};
+	relationships: { show: { data: { id: string; type: string } } };
 }
 
-export interface HboMaxMovieMetadata {
-	titles: {
-		full: string;
-	};
-	releaseYear: number;
+export interface HbomaxProfileData {
+	data: { attributes: { profileName: string } };
 }
 
-export interface HboMaxAuthResponse {
-	access_token: string;
-	refresh_token: string;
-
-	/** In seconds */
-	expires_in: number;
+export interface HbomaxRouting {
+	homeMarket: string;
+	env: string;
+	tenant: string;
+	domain: string;
 }
 
-export interface HboMaxConfigResponse {
-	routeKeys: {
-		userSubdomain: string;
-	};
+export interface CachedRouting {
+	routing?: HbomaxRouting;
+	timestamp: number;
 }
 
-export type HboMaxProfileResponse = HboMaxContentResponse<HboMaxProfileResponseItem>;
+class _HbomaxApi extends ServiceApi {
+	public session: HbomaxSession | null = null;
+	public hasReachedHistoryEnd = false;
+	public currentHistoryPage = 1;
+	public showIdsParam = '';
+	public showNameMap: Record<string, string> = {};
+	public isActivated = false;
 
-export interface HboMaxProfileResponseItem {
-	profiles: HboMaxProfile[];
-}
-
-export type HboMaxHistoryResponse = HboMaxHistoryResponseItem[];
-
-export interface HboMaxHistoryResponseItem {
-	/**
-	 * Formats:
-	 *
-	 * - urn:hbo:episode:XXXXXXXXXXXXXXXXXXXX
-	 * - urn:hbo:feature:XXXXXXXXXXXXXXXXXXXX
-	 */
-	id: string;
-
-	position: number;
-	runtime: number;
-
-	/** Format: yyyy-MM-ddTHH:mm:ssZ */
-	created: string;
-}
-
-export type HboMaxItemMetadataResponse = HboMaxContentResponse<
-	HboMaxEpisodeMetadata | HboMaxMovieMetadata
->;
-
-export type HboMaxContentResponse<T> = (
-	| HboMaxContentSuccessResponse<T>
-	| HboMaxContentErrorResponse
-)[];
-
-export interface HboMaxContentSuccessResponse<T> {
-	id: string;
-	body: T;
-}
-
-export interface HboMaxContentErrorResponse {
-	id: string;
-	body: {
-		message: string;
-	};
-}
-
-class _HboMaxApi extends ServiceApi {
-	HOST_URL = 'https://play.hbomax.com';
-	API_BASE = 'api.hbo.com';
-	GLOBAL_AUTH_URL = `https://oauth.${this.API_BASE}/auth/tokens`;
-	LOCAL_AUTH_URL = `https://gateway{subdomain}.${this.API_BASE}/auth/tokens`;
-	CONFIG_URL = `https://sessions.${this.API_BASE}/sessions/v1/clientConfig`;
-	CONTENT_URL = `https://comet{subdomain}.${this.API_BASE}/content`;
-	HISTORY_URL = `https://markers{subdomain}.${this.API_BASE}/markers`;
-
-	/**
-	 * These values were retrieved from https://play.hbomax.com/js/app.js:
-	 *
-	 * - to find `CLIENT_VERSION`, search for `versionString="` to get the first fragment, then search for `displayVersion:"` to get the next fragment, and the last fragment should be the platform (`desktop`)
-	 * - to find `CLIENT_ID`, search for `ClientIDs:{` and get the `desktop` property
-	 * - to find `CONTRACT`, search for `contract:"`
-	 */
-	CLIENT_VERSION = 'Hadron/50.41.0.9 desktop';
-	CLIENT_ID = '585b02c8-dbe1-432f-b1bb-11cf670fbeb0';
-	CONTRACT = 'hadron:1.1.2.0';
-
-	requests = Requests;
-	authRequests = Requests;
-
-	isActivated = false;
-	session?: HboMaxSession | null;
+	private API_URL = 'https://default.any-any.prd.api.hbomax.com';
+	private PROFILE_URL = `${this.API_URL}/users/me/profiles/selected`;
+	private ALLSHOWS_URL =
+		`${this.API_URL}/cms/routes/my-stuff?include=default&decorators=viewingHistory,isFavorite,contentAction,badges&page[items.size]=100`;
 
 	constructor() {
 		super(HboMaxService.id);
 	}
 
-	async activate() {
-		if (this.session === null) {
+	/** Initialize the API URL using cached routing or bootstrap */
+	private async initApiUrl(): Promise<void> {
+		const env = 'prd';
+		const domain = 'api.hbomax.com';
+		const cacheKey = 'servicesData';
+		const ttl = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+		// Fetch cache wrapper
+		const cacheItem: CacheItem<'servicesData'> | undefined = await Cache.get(cacheKey);
+
+		// Read cached routing for this service
+		const cached = cacheItem?.get(this.id) as CachedRouting | undefined;
+		if (cached?.routing && Date.now() - cached.timestamp < ttl) {
+			this.applyRouting(cached.routing);
 			return;
 		}
 
+		// Fetch bootstrap routing from Discovery+
+		const bootstrapUrl = `https://default.any-any.${env}.${domain}/session-context/headwaiter/v1/bootstrap`;
+		const responseText = await Requests.send({
+			url: bootstrapUrl,
+			method: 'POST',
+			headers: {
+				'x-disco-client': 'WEB:10.15.7:hbomax:6.17.0',
+				'x-disco-params': 'realm=bolt,bid=beam,features=ar',
+			},
+			body: '{}',
+		});
+
+		const bootstrap = JSON.parse(responseText) as { routing?: HbomaxRouting };
+		if (!bootstrap.routing) throw new Error('Invalid bootstrap: missing routing');
+
+		this.applyRouting(bootstrap.routing);
+
+		// Save routing back to cache
+		cacheItem?.set(this.id, { routing: bootstrap.routing, timestamp: Date.now() });
+	}
+
+	/** Apply routing to API URLs */
+	private applyRouting(routing: HbomaxRouting): void {
+		this.API_URL = `https://default.${routing.tenant}-${routing.homeMarket}.${routing.env}.${routing.domain}`;
+		this.PROFILE_URL = `${this.API_URL}/users/me/profiles/selected`;
+		this.ALLSHOWS_URL = `${this.API_URL}/cms/routes/my-stuff?include=default&decorators=viewingHistory,isFavorite,contentAction,badges&page[items.size]=100`;
+	}
+
+	/** Activate service session */
+	async activate(): Promise<void> {
 		try {
-			const now = Utils.unix();
+			await this.initApiUrl();
 
-			const servicesData = await Cache.get('servicesData');
-			let cache = servicesData.get(this.id) as HboMaxData | undefined;
+			const response = await Requests.send({ url: this.PROFILE_URL, method: 'GET' });
+			const profileData = JSON.parse(response) as HbomaxProfileData;
 
-			if (!cache || cache.auth.expiresAt < now) {
-				if (!cache) {
-					const partialSession = await this.getSession();
-					if (!partialSession || !partialSession.auth || !partialSession.deviceSerialNumber) {
-						throw new Error();
-					}
-
-					cache = {
-						subdomain: '',
-						auth: partialSession.auth,
-						deviceSerialNumber: partialSession.deviceSerialNumber,
-					};
-				}
-
-				this.requests = withHeaders({
-					'x-hbo-client-version': this.CLIENT_VERSION,
-				});
-
-				const globalAuthResponseText = await this.requests.send({
-					url: this.GLOBAL_AUTH_URL,
-					method: 'POST',
-					body: {
-						client_id: this.CLIENT_ID,
-						client_secret: this.CLIENT_ID,
-						deviceSerialNumber: cache.deviceSerialNumber,
-						grant_type: 'client_credentials',
-						scope: 'browse video_playback_free',
-					},
-				});
-				const globalAuthResponse = JSON.parse(globalAuthResponseText) as HboMaxAuthResponse;
-
-				this.authRequests = withHeaders(
-					{
-						Authorization: `Bearer ${globalAuthResponse.access_token}`,
-					},
-					this.requests
-				);
-
-				const configResponseText = await this.authRequests.send({
-					url: this.CONFIG_URL,
-					method: 'POST',
-					body: {
-						contract: this.CONTRACT,
-						preferredLanguages: ['en-us'],
-					},
-				});
-				const configResponse = JSON.parse(configResponseText) as HboMaxConfigResponse;
-
-				cache.subdomain = configResponse.routeKeys.userSubdomain;
-
-				if (cache.auth.expiresAt < now) {
-					const localAuthResponseText = await this.authRequests.send({
-						url: Utils.replace(this.LOCAL_AUTH_URL, cache),
-						method: 'POST',
-						body: {
-							refresh_token: cache.auth.refreshToken,
-							grant_type: 'refresh_token',
-							scope: 'browse video_playback device',
-						},
-					});
-					const localAuthResponse = JSON.parse(localAuthResponseText) as HboMaxAuthResponse;
-
-					cache.auth.accessToken = localAuthResponse.access_token;
-					cache.auth.refreshToken = localAuthResponse.refresh_token;
-					cache.auth.expiresAt = now + localAuthResponse.expires_in;
-				}
-
-				servicesData.set(this.id, cache);
-				await Cache.set({ servicesData });
-			}
-
-			this.session = {
-				...cache,
-				profileName: null,
-			};
-
-			this.requests = withHeaders({
-				'x-hbo-client-version': this.CLIENT_VERSION,
-			});
-			this.authRequests = withHeaders(
-				{
-					Authorization: `Bearer ${this.session.auth.accessToken}`,
-				},
-				this.requests
-			);
-
+			this.session = { profileName: profileData.data.attributes.profileName };
 			this.isActivated = true;
-		} catch (_err) {
+		} catch (err) {
+			console.error('Activation failed:', err);
 			this.session = null;
 		}
-
-		if (!this.session) {
-			return;
-		}
-
-		try {
-			const profileResponseId = 'urn:hbo:profiles:mine';
-			const profileResponseText = await this.authRequests.send({
-				url: Utils.replace(this.CONTENT_URL, this.session),
-				method: 'POST',
-				body: [{ id: profileResponseId }],
-			});
-			const profileResponse = JSON.parse(profileResponseText) as HboMaxProfileResponse;
-			const profileResponseItem = profileResponse.find(
-				(currentItem) => currentItem.id === profileResponseId
-			);
-
-			if (profileResponseItem && !('message' in profileResponseItem.body)) {
-				const profile = profileResponseItem.body.profiles.find(
-					(currentProfile) => currentProfile.isMe
-				);
-				if (profile) {
-					this.session.profileName = profile.name;
-				}
-			}
-		} catch (_err) {
-			// Do nothing
-		}
 	}
 
-	async checkLogin() {
-		if (!this.isActivated) {
-			await this.activate();
-		}
-		return !!this.session && !!this.session.profileName;
+	/** Check if user is logged in */
+	async checkLogin(): Promise<boolean> {
+		if (!this.isActivated) await this.activate();
+		return !!this.session?.profileName;
 	}
 
-	async loadHistoryItems(cancelKey = 'default'): Promise<HboMaxHistoryItem[]> {
-		if (!this.isActivated) {
-			await this.activate();
-		}
-		if (!this.session) {
-			throw new Error('Invalid API session');
-		}
+	/** Fetch all series show IDs and populate showNameMap */
+	private async fetchSeriesShowIds(): Promise<string[]> {
+		const responseText = await Requests.send({ url: this.ALLSHOWS_URL, method: 'GET' });
+		const allShowsResponse = JSON.parse(responseText) as {
+			included?: Array<{ id: string; attributes?: { showType?: string; name?: string } }>;
+		};
 
-		const historyItems: HboMaxHistoryItem[] = [];
+		const showIds =
+			allShowsResponse.included
+				?.filter((item) => item.attributes?.showType === 'SERIES')
+				.map((item) => {
+					if (item.attributes?.name) this.showNameMap[item.id] = item.attributes.name;
+					return item.id;
+				}) ?? [];
 
-		const historyResponseText = await this.authRequests.send({
-			url: Utils.replace(this.HISTORY_URL, this.session),
-			method: 'GET',
-			cancelKey,
+		return showIds;
+	}
+
+	/** Load the next page of history items */
+	private async loadNextHistoryPage(): Promise<HbomaxHistoryItem[]> {
+		if (!this.showIdsParam) throw new Error('No show IDs set for history request');
+
+		const params = new URLSearchParams({
+			decorators: 'viewingHistory',
+			'filter[videoType]': 'EPISODE',
+			'filter[show.id]': `${this.showIdsParam}`,
+			'page[size]': '100',
+			'page[number]': `${this.currentHistoryPage}`,
 		});
-		const historyResponse = JSON.parse(historyResponseText) as HboMaxHistoryResponse;
-		const historyResponseItems = historyResponse.filter(
-			(item) => item.id.startsWith('urn:hbo:episode') || item.id.startsWith('urn:hbo:feature')
-		);
 
-		for (const historyResponseItem of historyResponseItems) {
-			historyItems.push({
-				id: historyResponseItem.id,
-				progress:
-					Math.round((historyResponseItem.position / historyResponseItem.runtime) * 10000) / 100,
-				watchedAt: Utils.unix(historyResponseItem.created),
-			});
-		}
+		const historyApiUrl = new URL(`${this.API_URL}/content/videos`);
+		historyApiUrl.search = params.toString();
 
-		this.hasReachedHistoryEnd = true;
+		const responseText = await Requests.send({ url: historyApiUrl.toString(), method: 'GET' });
+		const responseJson = JSON.parse(responseText) as {
+			data: HbomaxHistoryItem[];
+			meta: { totalPages: number };
+		};
 
+		const historyItems = responseJson?.data ?? [];
+		const totalPages = responseJson?.meta?.totalPages ?? 1;
+
+		this.hasReachedHistoryEnd = this.currentHistoryPage >= totalPages;
+		this.currentHistoryPage++;
 		return historyItems;
 	}
 
-	isNewHistoryItem(historyItem: HboMaxHistoryItem, lastSync: number) {
-		return historyItem.watchedAt > lastSync;
+	async loadHistoryForShow(showId: string): Promise<HbomaxHistoryItem[]> {
+		this.showIdsParam = showId;
+		this.currentHistoryPage = 1;
+		this.hasReachedHistoryEnd = false;
+
+		const items: HbomaxHistoryItem[] = [];
+		while (!this.hasReachedHistoryEnd) {
+			const pageItems = await this.loadNextHistoryPage();
+			items.push(...pageItems);
+		}
+		return items;
 	}
 
-	getHistoryItemId(historyItem: HboMaxHistoryItem) {
-		return historyItem.id;
+	/** Load all history items */
+	async loadHistoryItems(_cancelKey = 'default'): Promise<HbomaxHistoryItem[]> {
+		if (!this.isActivated) await this.activate();
+		if (!this.session) throw new Error('Invalid API session');
+
+		const showIds = await this.fetchSeriesShowIds();
+		if (!showIds.length) return [];
+
+		// Load all shows in parallel
+		const results = await Promise.all(showIds.map((id) => this.loadHistoryForShow(id)));
+
+		const allHistoryItems = results.flat();
+
+		const viewedEpisodes = allHistoryItems.filter(
+			(i) => i.attributes.videoType === 'EPISODE' && i.attributes.viewingHistory.viewed
+		);
+
+		viewedEpisodes.sort((a, b) => {
+			const t1 = Utils.unix(
+				a.attributes.viewingHistory?.lastReportedTimestamp ?? a.attributes.airDate
+			);
+			const t2 = Utils.unix(
+				b.attributes.viewingHistory?.lastReportedTimestamp ?? b.attributes.airDate
+			);
+			return t2 - t1;
+		});
+
+		return viewedEpisodes;
 	}
 
-	async convertHistoryItems(historyItems: HboMaxHistoryItem[]) {
+	/** Convert history items to ScrobbleItem array */
+	async convertHistoryItems(historyItems: HbomaxHistoryItem[]): Promise<ScrobbleItem[]> {
 		const items: ScrobbleItem[] = [];
 
-		for (const historyItem of historyItems) {
-			const item = await this.getItem(historyItem.id);
-			if (item) {
-				item.progress = historyItem.progress;
-				item.watchedAt = Utils.unix(historyItem.watchedAt);
-				items.push(item);
-			}
+		for (const ep of historyItems) {
+			const showId = ep.relationships.show.data.id ?? '';
+			const showName = this.showNameMap[showId] ?? 'Unknown Show';
+			const watchedAt = Utils.unix(
+				ep.attributes.viewingHistory?.lastReportedTimestamp ?? ep.attributes.airDate
+			);
+
+			// Simulate async processing if needed (or replace with actual async calls)
+			items.push(
+				await Promise.resolve(
+					new EpisodeItem({
+						serviceId: this.id,
+						id: ep.id,
+						title: ep.attributes.name,
+						season: ep.attributes.seasonNumber,
+						number: ep.attributes.episodeNumber,
+						year: new Date(ep.attributes.airDate ?? ep.attributes.firstAvailableDate).getFullYear(),
+						watchedAt,
+						progress: ep.attributes.viewingHistory?.completed ? 100 : 0,
+						show: { serviceId: this.id, id: showId, title: showName },
+					})
+				)
+			);
 		}
 
 		return items;
 	}
 
-	updateItemFromHistory(
-		item: ScrobbleItemValues,
-		historyItem: HboMaxHistoryItem
-	): Promisable<void> {
-		item.watchedAt = Utils.unix(historyItem.watchedAt);
-		item.progress = historyItem.progress;
-	}
-
-	parseItemMetadata(id: string, itemMetadata: HboMaxItemMetadata) {
-		let item: ScrobbleItem;
-
-		const serviceId = this.id;
-		const { releaseYear: year } = itemMetadata;
-
-		if ('seriesTitles' in itemMetadata) {
-			const title = itemMetadata.seriesTitles.full.trim();
-			const { seasonNumber: season, numberInSeason: number } = itemMetadata;
-			const episodeTitle = itemMetadata.titles.full.trim();
-
-			item = new EpisodeItem({
-				serviceId,
-				id,
-				title: episodeTitle,
-				year,
-				season,
-				number,
-				show: {
-					serviceId,
-					title,
-					year,
-				},
-			});
-		} else {
-			const title = itemMetadata.titles.full.trim();
-
-			item = new MovieItem({
-				serviceId,
-				id,
-				title,
-				year,
-			});
-		}
-
-		return item;
-	}
-
-	async getItem(id: string): Promise<ScrobbleItem | null> {
-		let item: ScrobbleItem | null = null;
-
-		if (!this.isActivated) {
-			await this.activate();
-		}
-		if (!this.session) {
-			throw new Error('Invalid API session');
-		}
-
-		try {
-			const responseText = await this.authRequests.send({
-				url: Utils.replace(this.CONTENT_URL, this.session),
-				method: 'POST',
-				body: [{ id }],
-			});
-			const response = JSON.parse(responseText) as HboMaxItemMetadataResponse;
-
-			const responseItem = response.find((currentItem) => currentItem.id === id);
-			if (responseItem && !('message' in responseItem.body)) {
-				const itemMetadata = responseItem.body;
-				item = this.parseItemMetadata(id, itemMetadata);
-			}
-		} catch (err) {
-			if (Shared.errors.validate(err)) {
-				Shared.errors.error('Failed to get item.', err);
-			}
-		}
-
-		return item;
-	}
-
-	async getSession(): Promise<Partial<HboMaxSession> | null> {
-		const result = await ScriptInjector.inject<Partial<HboMaxSession>>(
-			this.id,
-			'session',
-			this.HOST_URL
+	/** Update existing item from history */
+	updateItemFromHistory(item: ScrobbleItemValues, historyItem: HbomaxHistoryItem): void {
+		item.watchedAt = Utils.unix(
+			historyItem.attributes.viewingHistory?.lastReportedTimestamp ?? historyItem.attributes.airDate
 		);
-		if (result?.auth) {
-			result.auth.expiresAt = Utils.unix(result.auth.expiresAt);
-		}
-		return result;
+		item.progress = historyItem.attributes.viewingHistory?.completed ? 100 : 0;
+	}
+
+	/** Check if history item is new */
+	isNewHistoryItem(historyItem: HbomaxHistoryItem, lastSync: number): boolean {
+		return (
+			Utils.unix(
+				historyItem.attributes.viewingHistory?.lastReportedTimestamp ??
+					historyItem.attributes.airDate
+			) > lastSync
+		);
+	}
+
+	/** Get unique history item ID */
+	getHistoryItemId(historyItem: HbomaxHistoryItem): string {
+		return historyItem.id;
+	}
+
+	/** Get a single item by ID */
+	async getItem(id: string): Promise<ScrobbleItem | null> {
+		const allItems = await this.convertHistoryItems(await this.loadHistoryItems());
+		return allItems.find((i) => i.id === id) ?? null;
 	}
 }
 
-Shared.functionsToInject[`${HboMaxService.id}-session`] = () => {
-	const session: Partial<HboMaxSession> = {};
-
-	const authStr = window.localStorage.getItem('authToken');
-	if (authStr) {
-		const authObj = JSON.parse(authStr) as HboMaxAuthObj;
-		session.auth = {
-			accessToken: authObj.access_token,
-			refreshToken: authObj.refresh_token,
-			expiresAt: authObj.expires_on,
-		};
-	}
-
-	const deviceSerialNumber = window.localStorage.getItem('deviceSerialNumber');
-	if (deviceSerialNumber) {
-		session.deviceSerialNumber = deviceSerialNumber;
-	}
-
-	return session;
-};
-
-export const HboMaxApi = new _HboMaxApi();
+export const HboMaxApi = new _HbomaxApi();

--- a/src/services/hbo-max/HboMaxParser.ts
+++ b/src/services/hbo-max/HboMaxParser.ts
@@ -1,14 +1,75 @@
-import { HboMaxApi } from '@/hbo-max/HboMaxApi';
 import { ScrobbleParser } from '@common/ScrobbleParser';
+import { HboMaxApi } from '@/hbo-max/HboMaxApi';
+import { EpisodeItem, MovieItem } from '@models/Item';
 
 class _HboMaxParser extends ScrobbleParser {
 	constructor() {
 		super(HboMaxApi, {
-			/**
-			 * Format: https://play.hbomax.com/player/urn:hbo:episode:XXXXXXXXXXXXXXXXXXXX
-			 */
-			watchingUrlRegex: /\/(?:player)\/(?<id>[^/]+)/,
+			watchingUrlRegex: /video\/watch\/(?<showId>[a-f0-9-]+)\/(?<id>[a-f0-9-]+)/,
 		});
+	}
+
+	parseItemFromDom() {
+		const serviceId = this.api.id;
+		const id = this.parseItemIdFromUrl();
+		if (!id) return null;
+
+		const seasonEpisodeElement = document.querySelector(
+			'span[data-testid="player-ux-season-episode"]'
+		);
+
+		const movieTitleElement = document.querySelector('span[data-testid="player-ux-asset-title"]');
+
+		// EPISODE
+		if (seasonEpisodeElement) {
+			const labelElement = document.querySelector(
+				'p.StyledVisiblyHiddenLabel-Fuse-Web-Play__sc-ja1og5-1'
+			);
+			if (!labelElement) return null;
+
+			const fullLabel = labelElement.textContent?.trim() ?? '';
+			const parts = fullLabel.split(',');
+			const showTitle = parts[0]?.trim() ?? '';
+			const episodeTitle = parts.slice(2).join(',').trim() || parts[1]?.trim() || '';
+
+			let season = 0;
+			let number = 0;
+
+			const seText = seasonEpisodeElement.textContent ?? '';
+			const seMatch = /S(?<season>\d+)\s*E(?<episode>\d+)/i.exec(seText);
+			if (seMatch?.groups) {
+				season = parseInt(seMatch.groups.season) || 0;
+				number = parseInt(seMatch.groups.episode) || 0;
+			}
+
+			if (season && number) {
+				return new EpisodeItem({
+					serviceId,
+					id,
+					title: episodeTitle,
+					season,
+					number,
+					show: {
+						serviceId,
+						title: showTitle,
+					},
+				});
+			}
+		}
+
+		// MOVIE fallback
+		if (movieTitleElement) {
+			const title = movieTitleElement.textContent?.trim();
+			if (!title) return null;
+
+			return new MovieItem({
+				serviceId,
+				id,
+				title,
+			});
+		}
+
+		return null;
 	}
 }
 

--- a/src/services/hbo-max/HboMaxService.ts
+++ b/src/services/hbo-max/HboMaxService.ts
@@ -8,4 +8,7 @@ export const HboMaxService = new Service({
 	hasScrobbler: true,
 	hasSync: true,
 	hasAutoSync: true,
+	limitations: [
+		'Full history loads by show only, HBO Max removed ability to load several items at once.',
+	],
 });


### PR DESCRIPTION
Updated Discovery+ History due to call limitation
Changed HBO Max service to mirror Discovery+ (uses same API calls)
Added support for BBC iPlayer (UK) history (scrobbling not currently possible)
Added support for Channel4 (UK) history and scrobbling
Updated README to reflect new services and move AmanzonPrimeService Limitation to the correct service ts file

Closes #428 
Closes #310 
Closes #281 
Closes #280 
Closes #273 
Closes #246 
Closes #245 