### PR TITLE
fix: update Trakt OAuth callback to handle app.trakt.tv redirect

### DIFF
--- a/src/apis/TraktAuth.ts
+++ b/src/apis/TraktAuth.ts
@@ -47,7 +47,8 @@ class _TraktAuth extends TraktApi {
 	}
 
 	getCode(redirectUrl: string): string {
-		return redirectUrl.split('?')[1].split('=')[1];
+		const search = redirectUrl.includes('?') ? redirectUrl.split('?')[1] : redirectUrl;
+		return new URLSearchParams(search).get('code') ?? '';
 	}
 
 	hasTokenExpired(auth: TraktAuthDetails): boolean {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -246,7 +246,8 @@ const getManifest = (browserName: string, isDev: boolean): string => {
 		content_scripts: [
 			{
 				js: ['trakt.js'],
-				matches: ['*://*.trakt.tv/apps*'],
+				// Trakt redirects oauth callback from trakt.tv/apps to app.trakt.tv
+				matches: ['*://*.trakt.tv/apps*', '*://app.trakt.tv/*'],
 			},
 		],
 		default_locale: 'en',


### PR DESCRIPTION
Fixes #467

## Summary

Trakt changed their server-side OAuth redirect behavior: `https://trakt.tv/apps?code=...` now 301-redirects to `https://app.trakt.tv/?code=...&mode=media`. Because Chrome follows server-side redirects before injecting content scripts, `trakt.js` (matched on `*://*.trakt.tv/apps*`) never fires on the final URL — leaving login permanently pending.

- **`webpack.config.ts`**: Add `*://app.trakt.tv/*` to the content script `matches` so `trakt.js` runs on the new OAuth callback destination
- **`src/apis/TraktAuth.ts`**: Fix `getCode()` to use `URLSearchParams` instead of `split('=')[1]`, which was returning `"<code>&mode"` when Trakt appended `&mode=media` to the redirect URL

## Test plan

- [ ] Log out of the extension (or clear `auth` from `chrome.storage.local`)
- [ ] Click "Login with Trakt.tv" in the popup
- [ ] Authorize the app on Trakt's website
- [ ] Confirm login completes and the popup shows the logged-in state