### PR TITLE
Throttle Netflix item lookups and cache playback injection

### DIFF
--- a/src/services/netflix/NetflixParser.ts
+++ b/src/services/netflix/NetflixParser.ts
@@ -1,12 +1,39 @@
 import { NetflixApi, NetflixInjectedPlayback } from '@/netflix/NetflixApi';
 import { ScriptInjector } from '@common/ScriptInjector';
-import { ScrobbleParser } from '@common/ScrobbleParser';
+import { ScrobblePlayback, ScrobbleParser } from '@common/ScrobbleParser';
+import { ScrobbleItem } from '@models/Item';
 
 class _NetflixParser extends ScrobbleParser {
+	/**
+	 * How long (in ms) to wait before retrying `getItem` for an ID that failed to resolve.
+	 *
+	 * Netflix live content isn't always available in the metadata API right away, so unlike
+	 * the base parser - which blacklists a failing ID for the rest of the session - we keep
+	 * retrying so the item can resolve once it becomes available. The retry is throttled to
+	 * avoid hammering the API on every parse tick (which runs roughly every 500ms).
+	 */
+	private static readonly FAILING_ID_RETRY_INTERVAL = 30 * 1e3;
+
+	/**
+	 * How long (in ms) a single playback injection is reused for. Both the playback and the
+	 * item ID are derived from the same injected function, so caching it for a short window
+	 * collapses the multiple injections that happen within a single parse cycle into one,
+	 * while still refreshing on the next tick.
+	 */
+	private static readonly PLAYBACK_CACHE_TTL = 250;
+
+	private failingIds = new Map<string, number>();
+	private cachedPlayback: NetflixInjectedPlayback | null = null;
+	private cachedPlaybackAt = 0;
+
 	constructor() {
 		super(NetflixApi, {
 			watchingUrlRegex: /\/watch\/(?<id>\d+)/,
 		});
+	}
+
+	protected async parsePlaybackFromInjectedScript(): Promise<Partial<ScrobblePlayback> | null> {
+		return this.getInjectedPlayback();
 	}
 
 	protected async parseItemId(): Promise<string | null> {
@@ -18,17 +45,49 @@ class _NetflixParser extends ScrobbleParser {
 	}
 
 	protected async parseItemIdFromInjectedScript(): Promise<string | null> {
+		const playback = await this.getInjectedPlayback();
+		return playback?.videoId ?? null;
+	}
+
+	protected async parseItemFromApi(): Promise<ScrobbleItem | null> {
+		const id = await this.parseItemId();
+		if (!id) {
+			return null;
+		}
+
+		// Throttle retries for IDs that recently failed to resolve, so an unresolvable ID
+		// doesn't trigger a fresh round of API requests on every parse tick.
+		const lastFailedAt = this.failingIds.get(id);
+		if (
+			typeof lastFailedAt !== 'undefined' &&
+			Date.now() - lastFailedAt < _NetflixParser.FAILING_ID_RETRY_INTERVAL
+		) {
+			return null;
+		}
+
+		const item = await this.api.getItem(id);
+		if (item) {
+			this.failingIds.delete(id);
+		} else {
+			this.failingIds.set(id, Date.now());
+		}
+		return item;
+	}
+
+	private async getInjectedPlayback(): Promise<NetflixInjectedPlayback | null> {
+		const now = Date.now();
+		if (this.cachedPlayback && now - this.cachedPlaybackAt < _NetflixParser.PLAYBACK_CACHE_TTL) {
+			return this.cachedPlayback;
+		}
+
 		const playback = await ScriptInjector.inject<NetflixInjectedPlayback>(
 			this.api.id,
 			'playback',
 			''
 		);
-		return playback?.videoId ?? null;
-	}
-
-	protected async parseItemFromApi() {
-		const id = await this.parseItemId();
-		return id ? this.api.getItem(id) : null;
+		this.cachedPlayback = playback;
+		this.cachedPlaybackAt = now;
+		return playback;
 	}
 }
 


### PR DESCRIPTION
Follow-up to #457, addressing the review concerns @MrMamen raised on the merged PR. Rebased onto current master; still relevant after #475 (see below).

## Summary
- **Throttle unresolvable IDs.** The base `ScrobbleParser.parseItemFromApi` blacklists a failing ID via `failingId` so it isn't re-requested. The Netflix override drops that guard, so an ID that won't resolve triggers `getItem` (metadata requests + a history fetch) on every parse tick (~every 500ms). Instead of permanently blacklisting — which would reintroduce the live-content bug, since those IDs resolve only once available — failing IDs are now retried on a 30s interval.
- **Cache the playback injection.** Playback and item-ID are both derived from the same injected `netflix-playback` function, which was injected multiple times per parse cycle. They now share a single injection via a short (250ms) cache that still refreshes on the next tick.

Both changes are self-contained in `NetflixParser`; no base-class behavior is altered for other services.

## Still needed after #475
#475 swapped the metadata endpoint but did not add any throttling to the live-scrobble path:
- `NetflixParser.parseItemFromApi` has no failing-ID guard (it overrides the base parser's `failingId` blacklist), and
- the live lookup `getItem → getItemFromMetadata → fetchSingleMetadata` is uncached (the new `metadataCache` only covers the history path) and now tries up to 4 URL variations per call.

So an unresolvable/live ID still hits ~4 metadata GETs + a history fetch on every parse tick. This PR addresses exactly that flooding without reintroducing the #457 live-content bug.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `biome check` passes
- [x] `build-dev` compiles
- [x] Manual: on-demand show and movie scrobble correctly — play/pause/resume detected and item resolved (show → season/episode/title, movie → title/year) via the `release/metadata` endpoint
- [x] Manual: rebased onto current master; no conflicts (MERGEABLE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)