### PR TITLE
Fix history sync hanging on rate-limited or invalid requests

### DIFF
--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -120,6 +120,10 @@ export abstract class ServiceApi {
 				}
 			}
 		} catch (err) {
+			console.debug(
+				`[UTS] Failed to load Trakt data for "${item.getFullTitle()}" (${item.serviceId})`,
+				err
+			);
 			if (item.trakt) {
 				delete item.trakt.watchedAt;
 			} else {

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -24,6 +24,16 @@ class _Requests {
 	readonly withHeaders: Record<string, string> = {};
 
 	async send(request: RequestDetails, tabId = Shared.tabId): Promise<string> {
+		if (!request.url || !/^https?:\/\//.test(request.url)) {
+			// An empty or relative URL would make the background page fetch its own bundle,
+			// which the Cloudflare detection below used to misinterpret as a rate limit response.
+			console.error('[UTS] Request with invalid URL', request, new Error().stack);
+			throw new RequestError({
+				request,
+				status: -1,
+				text: `Invalid request URL: "${request.url}"`,
+			});
+		}
 		return new Promise((resolve, reject) => {
 			if (Shared.pageType === 'background') {
 				void this.sendDirectly(request, tabId, resolve, reject);
@@ -35,11 +45,19 @@ class _Requests {
 		});
 	}
 
+	/**
+	 * The maximum number of times a rate-limited request (Cloudflare 1015 or HTTP 429) is retried
+	 * before rejecting. Without a cap, the request promise never settles, which leaves callers
+	 * (e.g. the history sync page) hanging forever. Rejecting lets the UI surface an error instead.
+	 */
+	readonly MAX_RATE_LIMIT_RETRIES = 2;
+
 	async sendDirectly(
 		request: RequestDetails,
 		tabId = Shared.tabId,
 		resolve: PromiseResolve<string>,
-		reject: PromiseReject
+		reject: PromiseReject,
+		rateLimitAttempt = 0
 	): Promise<void> {
 		let responseStatus = 0;
 		let responseText = '';
@@ -48,8 +66,15 @@ class _Requests {
 			responseStatus = response.status;
 			responseText = await response.text();
 
-			// Check for Cloudflare rate limiting HTML response
-			if (responseText.includes('Cloudflare') && responseText.includes('Ray ID:')) {
+			// Check for Cloudflare rate limiting HTML response.
+			// Only sniff error responses: Cloudflare error pages always come with an error status
+			// (429 for rate limiting, 403/503 for blocks). Sniffing successful responses caused
+			// false positives when the response body happened to contain these strings.
+			if (
+				responseStatus >= 400 &&
+				responseText.includes('Cloudflare') &&
+				responseText.includes('Ray ID:')
+			) {
 				// Extract error code if present (e.g., Error 1015)
 				const errorMatch = responseText.match(/Error\s*(\d+)/);
 				const errorCode = errorMatch ? errorMatch[1] : 'unknown';
@@ -60,11 +85,20 @@ class _Requests {
 					// Cloudflare doesn't provide Retry-After header in HTML error pages
 					// Use a reasonable default wait time (60 seconds)
 					const retryAfter = 60000;
-					console.warn(
-						`Cloudflare rate limit detected (Error ${errorCode}). Retrying in ${retryAfter / 1000}s`
-					);
-					setTimeout(() => void this.sendDirectly(request, tabId, resolve, reject), retryAfter);
-					return;
+					if (
+						this.scheduleRateLimitRetry(
+							request,
+							tabId,
+							resolve,
+							reject,
+							rateLimitAttempt,
+							retryAfter,
+							`Cloudflare rate limit (Error ${errorCode})`
+						)
+					) {
+						return;
+					}
+					throw responseText;
 				}
 
 				responseStatus = responseStatus || 503;
@@ -75,8 +109,20 @@ class _Requests {
 				const retryAfterStr = response.headers.get('Retry-After');
 				if (retryAfterStr) {
 					const retryAfter = Number.parseInt(retryAfterStr) * 1000;
-					setTimeout(() => void this.sendDirectly(request, tabId, resolve, reject), retryAfter);
-					return;
+					if (
+						this.scheduleRateLimitRetry(
+							request,
+							tabId,
+							resolve,
+							reject,
+							rateLimitAttempt,
+							retryAfter,
+							'HTTP 429'
+						)
+					) {
+						return;
+					}
+					throw responseText;
 				}
 			}
 			if (responseStatus < 200 || responseStatus >= 400) {
@@ -123,6 +169,49 @@ class _Requests {
 			return;
 		}
 		resolve(responseText);
+	}
+
+	/**
+	 * Schedules a retry for a rate-limited request, unless the retry limit has been reached or the
+	 * request has been canceled. Returns `true` if a retry was scheduled (or the request was
+	 * rejected as canceled), `false` if the caller should give up and throw.
+	 */
+	private scheduleRateLimitRetry(
+		request: RequestDetails,
+		tabId: number | null,
+		resolve: PromiseResolve<string>,
+		reject: PromiseReject,
+		rateLimitAttempt: number,
+		retryAfter: number,
+		reason: string
+	): boolean {
+		if (request.signal?.aborted) {
+			console.debug(`[UTS] ${reason} for ${request.url}, but request was canceled. Giving up.`);
+			reject(
+				new RequestError({
+					request,
+					status: 429,
+					isCanceled: true,
+				})
+			);
+			return true;
+		}
+
+		if (rateLimitAttempt >= this.MAX_RATE_LIMIT_RETRIES) {
+			console.warn(
+				`[UTS] ${reason} for ${request.url}: giving up after ${rateLimitAttempt} retries`
+			);
+			return false;
+		}
+
+		console.warn(
+			`[UTS] ${reason} for ${request.url}: retrying in ${retryAfter / 1000}s (attempt ${rateLimitAttempt + 1}/${this.MAX_RATE_LIMIT_RETRIES})`
+		);
+		setTimeout(
+			() => void this.sendDirectly(request, tabId, resolve, reject, rateLimitAttempt + 1),
+			retryAfter
+		);
+		return true;
 	}
 
 	async fetch(request: RequestDetails, tabId = Shared.tabId): Promise<Response> {

--- a/src/common/Requests.ts
+++ b/src/common/Requests.ts
@@ -207,10 +207,22 @@ class _Requests {
 		console.warn(
 			`[UTS] ${reason} for ${request.url}: retrying in ${retryAfter / 1000}s (attempt ${rateLimitAttempt + 1}/${this.MAX_RATE_LIMIT_RETRIES})`
 		);
-		setTimeout(
-			() => void this.sendDirectly(request, tabId, resolve, reject, rateLimitAttempt + 1),
-			retryAfter
-		);
+		setTimeout(() => {
+			// Re-check the abort signal: the request may have been canceled while waiting for the
+			// backoff timer, and `fetch()` would otherwise create a new `AbortController` for it,
+			// effectively "uncanceling" the retry.
+			if (request.signal?.aborted) {
+				reject(
+					new RequestError({
+						request,
+						status: 429,
+						isCanceled: true,
+					})
+				);
+				return;
+			}
+			void this.sendDirectly(request, tabId, resolve, reject, rateLimitAttempt + 1);
+		}, retryAfter);
 		return true;
 	}
 

--- a/src/modules/history/components/HistoryList.tsx
+++ b/src/modules/history/components/HistoryList.tsx
@@ -130,8 +130,8 @@ export const HistoryList = (): JSX.Element => {
 			);
 			items = await checkHiddenSelected(items);
 			items = await loadData(items);
-		} catch (_err) {
-			// Do nothing
+		} catch (err) {
+			console.debug('[UTS] Failed to load history items', err);
 		}
 		await stopLoading(items);
 		await checkEnd();


### PR DESCRIPTION
  The Cloudflare rate limit handling introduced in #459 retried failed requests every 60s indefinitely without ever settling the promise, which left the history sync page permanently stuck with disabled checkboxes. It also sniffed successful responses for Cloudflare markers, so a request with an empty URL (which fetches the extension's own bundle, containing those markers) was misdetected as a rate limit.

  - Cap rate limit retries at 2, then reject so the UI shows an error
  - Only sniff for Cloudflare error pages on responses with status >= 400
  - Reject requests with empty or non-http URLs immediately
  - Stop retrying when the request has been canceled
  - Add debug logging where errors were previously swallowed silently

  Fixes #465
