### PR TITLE
Fail fast when an episode lacks info to search Trakt with

### DIFF
--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -321,7 +321,12 @@ class _TraktSearch extends TraktApi {
 			console.debug(
 				`[UTS] Not enough information to search for episode "${item.getFullTitle()}" (${item.serviceId})`
 			);
-			throw new Error(`Not enough information to search for episode: ${item.getFullTitle()}`);
+			// Throw a 404 so the notification layer surfaces this as "not found"
+			// rather than a Trakt connectivity problem
+			throw new RequestError({
+				status: 404,
+				text: `Not enough information to search for episode: ${item.getFullTitle()}`,
+			});
 		}
 
 		try {

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -314,6 +314,16 @@ class _TraktSearch extends TraktApi {
 		let url = this.getEpisodeUrl(item, showItem.show.ids.trakt);
 		let responseText: string | null = null;
 
+		// `getEpisodeUrl` returns an empty string when the item has no season/episode numbers and
+		// no title to search by (e.g. NRK history items with an empty subtitle). There is nothing
+		// to send a request with, so fail fast and let the caller mark the item as unmatched.
+		if (!url) {
+			console.debug(
+				`[UTS] Not enough information to search for episode "${item.getFullTitle()}" (${item.serviceId})`
+			);
+			throw new Error(`Not enough information to search for episode: ${item.getFullTitle()}`);
+		}
+
 		try {
 			responseText = await this.requests.send({
 				url: url,

--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -181,7 +181,9 @@ class _NrkApi extends ServiceApi {
 	}
 
 	async loadHistoryItems(cancelKey = 'default'): Promise<NrkProgressItem[]> {
-		if (!this.isActivated) {
+		// `reset()` clears `nextHistoryUrl` without clearing `isActivated`, so re-activate
+		// whenever the URL is missing to avoid sending a request with an empty URL.
+		if (!this.isActivated || !this.nextHistoryUrl) {
 			await this.activate();
 		}
 		const responseText = await this.authRequests.send({


### PR DESCRIPTION
Some NRK history items have an empty subtitle, leaving the episode item without season/episode numbers or a title. getEpisodeUrl() then returns an empty string, which was sent as a request URL - the background page would fetch its own bundle and fail in confusing ways (see #470 for the worst case). NRK could also send an empty history URL after reset(), which clears nextHistoryUrl without clearing isActivated.

  - Throw a clear error in findEpisode instead of requesting an
    empty URL, so the item is marked as unmatched
  - Re-activate the NRK API when nextHistoryUrl is missing
