### PR TITLE
Gate expensive episode fallbacks behind absolute numbering flag

### DIFF
--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -321,7 +321,12 @@ class _TraktSearch extends TraktApi {
 			console.debug(
 				`[UTS] Not enough information to search for episode "${item.getFullTitle()}" (${item.serviceId})`
 			);
-			throw new Error(`Not enough information to search for episode: ${item.getFullTitle()}`);
+			// Throw a 404 so the notification layer surfaces this as "not found"
+			// rather than a Trakt connectivity problem
+			throw new RequestError({
+				status: 404,
+				text: `Not enough information to search for episode: ${item.getFullTitle()}`,
+			});
 		}
 
 		try {

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -344,16 +344,19 @@ class _TraktSearch extends TraktApi {
 			if (
 				item.isAbsolute &&
 				Shared.errors.validate(error) &&
-				((error as RequestError).status === 404 || (error as RequestError).status === -1) &&
-				item.title &&
-				!item.title.startsWith('Episode')
+				((error as RequestError).status === 404 || (error as RequestError).status === -1)
 			) {
 				console.debug(
 					`[UTS] Episode lookup failed for "${item.getFullTitle()}", trying TMDB/absolute-numbering fallbacks`
 				);
-				const tmdbResult = await this.tryTmdbFallback(item, showItem, cancelKey);
-				if (tmdbResult) {
-					return this.parseEpisodeResponse(tmdbResult, item, showItem);
+				// The TMDB fallback searches by episode title, so it requires a meaningful one.
+				// Generic titles like "Episode 12" skip straight to the absolute-numbering
+				// fallback, which doesn't depend on the title.
+				if (item.title && !item.title.startsWith('Episode')) {
+					const tmdbResult = await this.tryTmdbFallback(item, showItem, cancelKey);
+					if (tmdbResult) {
+						return this.parseEpisodeResponse(tmdbResult, item, showItem);
+					}
 				}
 
 				// If TMDB also fails, try treating numbers as absolute

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -314,6 +314,16 @@ class _TraktSearch extends TraktApi {
 		let url = this.getEpisodeUrl(item, showItem.show.ids.trakt);
 		let responseText: string | null = null;
 
+		// `getEpisodeUrl` returns an empty string when the item has no season/episode numbers and
+		// no title to search by (e.g. NRK history items with an empty subtitle). There is nothing
+		// to send a request with, so fail fast and let the caller mark the item as unmatched.
+		if (!url) {
+			console.debug(
+				`[UTS] Not enough information to search for episode "${item.getFullTitle()}" (${item.serviceId})`
+			);
+			throw new Error(`Not enough information to search for episode: ${item.getFullTitle()}`);
+		}
+
 		try {
 			responseText = await this.requests.send({
 				url: url,

--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -336,13 +336,21 @@ class _TraktSearch extends TraktApi {
 				cancelKey,
 			});
 		} catch (error) {
-			// If provided numbers don't work, try TMDB fallback first
+			// If provided numbers don't work, try TMDB fallback first.
+			// The fallbacks are gated behind `isAbsolute` because they cost several extra requests
+			// per item; running them for every failed lookup from every service can trigger Trakt's
+			// rate limit during history sync. Only services with absolute episode numbering
+			// (e.g. Crunchyroll) set the flag.
 			if (
+				item.isAbsolute &&
 				Shared.errors.validate(error) &&
 				((error as RequestError).status === 404 || (error as RequestError).status === -1) &&
 				item.title &&
 				!item.title.startsWith('Episode')
 			) {
+				console.debug(
+					`[UTS] Episode lookup failed for "${item.getFullTitle()}", trying TMDB/absolute-numbering fallbacks`
+				);
 				const tmdbResult = await this.tryTmdbFallback(item, showItem, cancelKey);
 				if (tmdbResult) {
 					return this.parseEpisodeResponse(tmdbResult, item, showItem);

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -54,6 +54,12 @@ export interface EpisodeItemValues extends BaseItemValues {
 	type: 'episode';
 	season: number;
 	number: number;
+	/**
+	 * Indicates that `number` may be an absolute episode number (numbered sequentially across all
+	 * seasons, e.g. anime episodes from Crunchyroll) rather than a per-season number, so episode
+	 * matching is allowed to fall back to resolving it against the show's season data.
+	 */
+	isAbsolute?: boolean;
 	show: ShowItemValues;
 	trakt?: TraktEpisodeItemValues | null;
 }
@@ -186,6 +192,7 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 	type = 'episode' as const;
 	season: number;
 	number: number;
+	isAbsolute?: boolean;
 	show: ShowItem;
 	trakt?: TraktEpisodeItem | null;
 
@@ -193,6 +200,7 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 		super(values);
 		this.season = values.season;
 		this.number = values.number;
+		this.isAbsolute = values.isAbsolute;
 		this.show = new ShowItem(values.show);
 		this.trakt = values.trakt && new TraktEpisodeItem(values.trakt);
 	}
@@ -203,6 +211,7 @@ export class EpisodeItem extends BaseItem implements EpisodeItemValues {
 			type: this.type,
 			season: this.season,
 			number: this.number,
+			isAbsolute: this.isAbsolute,
 			show: this.show.save(),
 			trakt: this.trakt?.save(),
 		};

--- a/src/services/crunchyroll/CrunchyrollApi.ts
+++ b/src/services/crunchyroll/CrunchyrollApi.ts
@@ -199,6 +199,9 @@ class _CrunchyrollApi extends ServiceApi {
 							: title,
 					number: metadata.episode_number || 0,
 					season: metadata.season_number || 0,
+					// Crunchyroll often numbers anime episodes sequentially across all seasons,
+					// so allow episode matching to resolve the number as absolute.
+					isAbsolute: true,
 					year: new Date(metadata.episode_air_date).getUTCFullYear(),
 					watchedAt: Utils.unix(historyItem.date_played),
 					progress: historyItem.fully_watched

--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -181,7 +181,9 @@ class _NrkApi extends ServiceApi {
 	}
 
 	async loadHistoryItems(cancelKey = 'default'): Promise<NrkProgressItem[]> {
-		if (!this.isActivated) {
+		// `reset()` clears `nextHistoryUrl` without clearing `isActivated`, so re-activate
+		// whenever the URL is missing to avoid sending a request with an empty URL.
+		if (!this.isActivated || !this.nextHistoryUrl) {
 			await this.activate();
 		}
 		const responseText = await this.authRequests.send({


### PR DESCRIPTION
The TMDB and absolute-numbering fallbacks added in #459 ran for every failed episode lookup from every service, costing several extra Trakt requests per item. During history sync with many unmatched items this can trigger Trakt's rate limit.

Introduce EpisodeItem.isAbsolute (described in the #459 commit message but never actually added) and only run the fallbacks when it's set. Crunchyroll, which numbers anime episodes sequentially across seasons, marks its episodes with the flag, preserving the behavior #459 was added for.