### PR TITLE
Dedupe Trakt token refresh and preserve session on transient errors

### DIFF
--- a/src/apis/TraktAuth.ts
+++ b/src/apis/TraktAuth.ts
@@ -1,5 +1,6 @@
 import { TraktApi } from '@apis/TraktApi';
 import { Messaging } from '@common/Messaging';
+import { RequestError } from '@common/RequestError';
 import { Shared } from '@common/Shared';
 import { Tabs } from '@common/Tabs';
 import { Utils } from '@common/Utils';
@@ -22,6 +23,7 @@ export type TraktAuthDetails = {
 class _TraktAuth extends TraktApi {
 	isIdentityAvailable: boolean;
 	manualAuth: TraktManualAuth;
+	private refreshPromise: Promise<TraktAuthDetails> | null = null;
 
 	constructor() {
 		super();
@@ -128,7 +130,12 @@ class _TraktAuth extends TraktApi {
 			auth = JSON.parse(responseText) as TraktAuthDetails;
 			await Shared.storage.set({ auth }, true);
 		} catch (err) {
-			await Shared.storage.remove('auth', true);
+			// Only drop the stored auth when Trakt rejects the credentials themselves
+			// (invalid/expired refresh token). Transient failures — 429 rate limiting,
+			// 5xx, network — must keep the refresh_token so the session can recover.
+			if (err instanceof RequestError && (err.status === 400 || err.status === 401)) {
+				await Shared.storage.remove('auth', true);
+			}
 			throw err;
 		}
 		return auth;
@@ -153,16 +160,21 @@ class _TraktAuth extends TraktApi {
 		if (Shared.pageType !== 'background') {
 			return Messaging.toExtension({ action: 'validate-trakt-token' });
 		}
-		let auth: TraktAuthDetails | null = null;
 		const values = await Shared.storage.get('auth');
-		if (values.auth) {
-			if (values.auth.refresh_token && this.hasTokenExpired(values.auth)) {
-				auth = await this.refreshToken(values.auth.refresh_token);
-			} else {
-				auth = values.auth;
-			}
+		if (!values.auth) {
+			return null;
 		}
-		return auth;
+		if (values.auth.refresh_token && this.hasTokenExpired(values.auth)) {
+			// Collapse concurrent refreshes (BrowserStorage.init + LoginPage +
+			// content scripts) into a single /oauth/token request.
+			const refreshPromise = (this.refreshPromise ??= this.refreshToken(
+				values.auth.refresh_token
+			).finally(() => {
+				this.refreshPromise = null;
+			}));
+			return refreshPromise;
+		}
+		return values.auth;
 	}
 }
 


### PR DESCRIPTION
Trakt has gotten more strict when it comes to rate limits. That resulted in me no longer being able to use the extension because I got into a rate limit loop. This PR should fix it and handle token requests better. 

## Problem

In local dev the popup would fail to render and the Network tab showed
`POST https://api.trakt.tv/oauth/token` → **429 Too Many Requests**. The 429 is
enforced by Trakt, but it's caused and sustained by the token-refresh path:

1. **No deduplication of in-flight refreshes.** When the stored access token is
   expired, every entry point that calls `Session.checkLogin()` →
   `TraktAuth.validateToken()` independently fires its own `refreshToken()` →
   `POST /oauth/token`. On the popup path both `BrowserStorage.init()` and
   `LoginPage`'s `useEffect` trigger this (plus the background's own `init()` on
   reload), and the retry layer in `Requests` adds more attempts. These stack up
   and trip Trakt's auth rate limit.

2. **A transient 429 destroys the session.** `requestToken()` removed the stored
   `auth` on *any* error, so a rate-limit response discarded the still-valid
   `refresh_token` and forced a full re-login — racing with concurrent refreshes
   that may have just succeeded.

(The token-expiry check itself is correct — `Utils.unix()` is in seconds,
matching `created_at + expires_in` — so this is concurrency + redundant triggers
+ retry amplification, not a "refresh on every call" bug.)

## Changes

Both in `src/apis/TraktAuth.ts`:

- **Dedupe in-flight refresh** — `validateToken()` collapses concurrent
  expired-token refreshes into a single shared `refreshPromise`, so only one
  `/oauth/token` request is ever in flight. The field resets in `.finally()`, so
  the next call reads the fresh token without re-requesting.
- **Preserve session on transient failures** — `requestToken()` now clears the
  stored `auth` only on `400`/`401` (Trakt rejecting the credentials). `429`,
  `5xx`, and network errors keep the `refresh_token` so the session recovers
  once the condition clears.

The duplicate `checkLogin()` on the popup path is intentional (`LoginPage` needs
the event after it subscribes) and is made harmless by the dedup, so it's left
unchanged.

## Testing

- `tsc --noEmit` and `biome check` pass.
- Forced expiry (`auth.created_at = 0` in `chrome.storage.local`) and opened the
  popup: a single `POST /oauth/token` fires for the refresh even though both
  `BrowserStorage.init()` and `LoginPage` call `checkLogin()`; login then
  completes.
- Verified that a rate-limited refresh no longer removes the stored `auth`, so
  the `refresh_token` survives a transient 429.
