### PR TITLE
Hotstar: fix scrobbling after JioHotstar rebrand (JSON-LD + overlay parsing, ad-aware, SPA-safe)

### DIFF
--- a/src/services/hotstar/HotstarParser.ts
+++ b/src/services/hotstar/HotstarParser.ts
@@ -1,6 +1,6 @@
-import { ScrobbleParser } from '@common/ScrobbleParser';
+import { ScrobbleParser, ScrobblePlayback } from '@common/ScrobbleParser';
 import { HotstarApi } from '@/hotstar/HotstarApi';
-import { EpisodeItem, MovieItem } from '@models/Item';
+import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
 
 interface HotstarLdEpisode {
 	'@type'?: string;
@@ -23,6 +23,26 @@ interface HotstarLd {
 	containsSeason?: HotstarLdSeason | HotstarLdSeason[];
 }
 
+/**
+ * JioHotstar is a Next.js single-page app whose markup is hostile to scraping:
+ *
+ *   - The player uses build-hashed, obfuscated class names (e.g. `bO4AyXwRYHuSKMa5...`)
+ *     that change on every deploy, so structural/class selectors can't be relied on.
+ *   - The rich schema.org JSON-LD (`Movie` / `TVSeries`) is only server-rendered on a
+ *     full page load. After an in-app navigation (e.g. "Next Episode", autoplay) it is
+ *     NOT re-injected, so it goes stale/absent for the rest of the session.
+ *   - `document.title`, `og:title` and the URL's `episodeNumber`/`seasonId` query params
+ *     are unreliable after in-app navigation (title reverts to the generic site title,
+ *     and the query params are frequently off by one).
+ *
+ * So item parsing draws from two stable sources, in order:
+ *   1. JSON-LD          - clean and complete, but only on a full page load.
+ *   2. The player title overlay - an `aria-label` of the form
+ *      "<show>, Season N, Episode N, <title>" (with an "S<n> E<n> <title>" text fallback),
+ *      which the player keeps in the DOM and updates on in-app navigation.
+ *
+ * The content type (movie vs. show) is taken from the URL, which is always accurate.
+ */
 class _HotstarParser extends ScrobbleParser {
 	constructor() {
 		super(HotstarApi, {
@@ -37,12 +57,140 @@ class _HotstarParser extends ScrobbleParser {
 	}
 
 	/**
-	 * JioHotstar renders the player with build-hashed, obfuscated class names (e.g.
-	 * `bO4AyXwRYHuSKMa5...`) that change on every deploy, so the player DOM can't be
-	 * scraped reliably. The page does embed schema.org JSON-LD metadata (a `Movie` or
-	 * `TVSeries` node), which is stable and is what we parse instead.
+	 * The base class only re-parses the item once the cached one is cleared, which
+	 * normally happens on navigation via the controller's `stopScrobble()`. That clearing
+	 * is skipped when an item never matched on Trakt, and JioHotstar advances between
+	 * episodes through in-app navigation, so a stale item could otherwise stick and block
+	 * detection of the new content. Drop it as soon as the URL's content id changes so the
+	 * next tick re-parses what's actually playing.
 	 */
-	private parseLdJson(): HotstarLd | null {
+	async parsePlayback(): Promise<ScrobblePlayback | null> {
+		const item = this.getItem();
+		if (item) {
+			const currentId = this.parseItemIdFromUrl();
+			if (currentId && item.id !== currentId) {
+				this.clearItem();
+			}
+		}
+		return super.parsePlayback();
+	}
+
+	/**
+	 * Hotstar has no public metadata API we can query, so skip the API step - the base
+	 * implementation logs a "not implemented" error - and let parsing fall through to the
+	 * DOM.
+	 */
+	protected parseItemFromApi(): Promise<ScrobbleItem | null> {
+		return Promise.resolve(null);
+	}
+
+	parseItemFromDom(): ScrobbleItem | null {
+		const serviceId = this.api.id;
+		const id = this.parseItemIdFromUrl();
+		if (!id) {
+			return null;
+		}
+
+		const location = this.getLocation();
+		const ld = this.parseLdJson(id);
+		const heading = document.querySelector('h1')?.textContent?.trim() ?? '';
+
+		if (location.includes('/movies/')) {
+			const title = (ld?.['@type'] === 'Movie' ? ld.name : '') || heading;
+			if (!title) {
+				return null;
+			}
+			const year = ld?.['@type'] === 'Movie' ? parseInt(ld.releaseYear ?? '') || 0 : 0;
+			return new MovieItem({ serviceId, id, title, year });
+		}
+
+		if (location.includes('/shows/')) {
+			return this.parseEpisode(serviceId, id, ld, heading);
+		}
+
+		return null;
+	}
+
+	private parseEpisode(
+		serviceId: string,
+		id: string,
+		ld: HotstarLd | null,
+		heading: string
+	): ScrobbleItem | null {
+		// 1. JSON-LD (present on a full page load).
+		const types = Array.isArray(ld?.['@type']) ? ld?.['@type'] : [ld?.['@type']];
+		if (ld && types?.includes('TVSeries')) {
+			const season = Array.isArray(ld.containsSeason) ? ld.containsSeason[0] : ld.containsSeason;
+			const episode = season?.episode;
+			if (episode) {
+				return new EpisodeItem({
+					serviceId,
+					id,
+					title: episode.name ?? '',
+					season: parseInt(season?.seasonNumber ?? '') || 0,
+					number: parseInt(episode.episodeNumber ?? '') || 0,
+					show: { serviceId, title: ld.name ?? heading },
+				});
+			}
+		}
+
+		if (!heading) {
+			return null;
+		}
+
+		// 2. Player overlay aria-label "<show>, Season N, Episode N, <title>". The show part
+		// must match the heading so a recommendation/up-next rail can't be mistaken for the
+		// item currently playing.
+		for (const el of Array.from(document.querySelectorAll('[aria-label]'))) {
+			const label = el.getAttribute('aria-label') ?? '';
+			const match =
+				/^(?<show>.+?),\s*Season\s*(?<season>\d+),\s*Episode\s*(?<number>\d+),\s*(?<title>.+)$/i.exec(
+					label
+				);
+			if (match?.groups && match.groups.show.trim() === heading) {
+				return this.buildEpisode(serviceId, id, heading, match.groups);
+			}
+		}
+
+		// 3. Player overlay "S<season> E<number> <title>" text (fallback for the aria-label).
+		for (const el of Array.from(document.querySelectorAll('p, span'))) {
+			if (el.children.length) {
+				continue;
+			}
+			const match = /^S(?<season>\d+)\s*E(?<number>\d+)\s+(?<title>.+)$/.exec(
+				el.textContent?.trim() ?? ''
+			);
+			if (match?.groups && match.groups.title.length > 1) {
+				return this.buildEpisode(serviceId, id, heading, match.groups);
+			}
+		}
+
+		return null;
+	}
+
+	private buildEpisode(
+		serviceId: string,
+		id: string,
+		show: string,
+		groups: Record<string, string>
+	): EpisodeItem {
+		return new EpisodeItem({
+			serviceId,
+			id,
+			title: groups.title.trim(),
+			season: parseInt(groups.season) || 0,
+			number: parseInt(groups.number) || 0,
+			show: { serviceId, title: show },
+		});
+	}
+
+	/**
+	 * Parses the schema.org JSON-LD `Movie` / `TVSeries` node, but only returns it when its
+	 * url references the content id currently in the page URL. The id is matched exactly
+	 * (extracted from the url) rather than via substring, so a shorter id can't collide with
+	 * a longer one, and stale metadata left over from a previous page isn't trusted.
+	 */
+	private parseLdJson(id: string): HotstarLd | null {
 		const scripts = document.querySelectorAll<HTMLScriptElement>(
 			'script[type="application/ld+json"]'
 		);
@@ -54,61 +202,28 @@ class _HotstarParser extends ScrobbleParser {
 				continue;
 			}
 			const types = Array.isArray(data['@type']) ? data['@type'] : [data['@type']];
-			if (types.includes('Movie') || types.includes('TVSeries')) {
-				return data;
+			if (types.includes('Movie')) {
+				if (this.ldUrlMatchesId(data.url, id)) {
+					return data;
+				}
+			} else if (types.includes('TVSeries')) {
+				const season = Array.isArray(data.containsSeason)
+					? data.containsSeason[0]
+					: data.containsSeason;
+				if (this.ldUrlMatchesId(season?.episode?.url, id)) {
+					return data;
+				}
 			}
 		}
 		return null;
 	}
 
-	parseItemFromDom() {
-		const serviceId = this.api.id;
-		const id = this.parseItemIdFromUrl();
-		const ld = this.parseLdJson();
-
-		if (!id || !ld) {
-			return null;
+	private ldUrlMatchesId(url: string | undefined, id: string): boolean {
+		if (!url) {
+			return false;
 		}
-
-		const types = Array.isArray(ld['@type']) ? ld['@type'] : [ld['@type']];
-
-		if (types.includes('TVSeries')) {
-			const season = Array.isArray(ld.containsSeason) ? ld.containsSeason[0] : ld.containsSeason;
-			const episode = season?.episode;
-
-			// Guard against stale metadata after an in-app (SPA) navigation: only trust
-			// the JSON-LD if it points at the episode the URL currently references.
-			if (!episode || (episode.url && !episode.url.includes(id))) {
-				return null;
-			}
-
-			return new EpisodeItem({
-				serviceId,
-				id,
-				title: episode.name ?? '',
-				season: parseInt(season?.seasonNumber ?? '') || 0,
-				number: parseInt(episode.episodeNumber ?? '') || 0,
-				show: {
-					serviceId,
-					title: ld.name ?? '',
-				},
-			});
-		}
-
-		if (types.includes('Movie')) {
-			if (ld.url && !ld.url.includes(id)) {
-				return null;
-			}
-
-			return new MovieItem({
-				serviceId,
-				id,
-				title: ld.name ?? '',
-				year: parseInt(ld.releaseYear ?? '') || 0,
-			});
-		}
-
-		return null;
+		const match = /\/(\d+)\/watch\/?$/.exec(url) ?? /\/(\d+)\/?$/.exec(url);
+		return match?.[1] === id;
 	}
 }
 

--- a/src/services/hotstar/HotstarParser.ts
+++ b/src/services/hotstar/HotstarParser.ts
@@ -2,6 +2,27 @@ import { ScrobbleParser } from '@common/ScrobbleParser';
 import { HotstarApi } from '@/hotstar/HotstarApi';
 import { EpisodeItem, MovieItem } from '@models/Item';
 
+interface HotstarLdEpisode {
+	'@type'?: string;
+	episodeNumber?: string;
+	name?: string;
+	url?: string;
+}
+
+interface HotstarLdSeason {
+	'@type'?: string;
+	seasonNumber?: string;
+	episode?: HotstarLdEpisode;
+}
+
+interface HotstarLd {
+	'@type'?: string | string[];
+	name?: string;
+	url?: string;
+	releaseYear?: string;
+	containsSeason?: HotstarLdSeason | HotstarLdSeason[];
+}
+
 class _HotstarParser extends ScrobbleParser {
 	constructor() {
 		super(HotstarApi, {
@@ -9,56 +30,79 @@ class _HotstarParser extends ScrobbleParser {
 		});
 	}
 
+	/**
+	 * JioHotstar renders the player with build-hashed, obfuscated class names (e.g.
+	 * `bO4AyXwRYHuSKMa5...`) that change on every deploy, so the player DOM can't be
+	 * scraped reliably. The page does embed schema.org JSON-LD metadata (a `Movie` or
+	 * `TVSeries` node), which is stable and is what we parse instead.
+	 */
+	private parseLdJson(): HotstarLd | null {
+		const scripts = document.querySelectorAll<HTMLScriptElement>(
+			'script[type="application/ld+json"]'
+		);
+		for (const script of Array.from(scripts)) {
+			let data: HotstarLd;
+			try {
+				data = JSON.parse(script.textContent ?? '') as HotstarLd;
+			} catch (_err) {
+				continue;
+			}
+			const types = Array.isArray(data['@type']) ? data['@type'] : [data['@type']];
+			if (types.includes('Movie') || types.includes('TVSeries')) {
+				return data;
+			}
+		}
+		return null;
+	}
+
 	parseItemFromDom() {
 		const serviceId = this.api.id;
 		const id = this.parseItemIdFromUrl();
-		const titleElement = document.querySelector(
-			'div#page-container>div>div>div>div>div>div>div>div>div>div.flex.flex-col>div.flex>p.ON_IMAGE.BUTTON1_MEDIUM'
-		);
+		const ld = this.parseLdJson();
 
-		if (!titleElement) {
+		if (!id || !ld) {
 			return null;
 		}
 
-		const title = titleElement?.textContent ?? '';
-		const subTitleElement = document.querySelector(
-			'div#page-container>div>div>div>div>div>div>div>div>div>div.flex.flex-col>p.ON_IMAGE_ALT2.BUTTON3_MEDIUM'
-		);
+		const types = Array.isArray(ld['@type']) ? ld['@type'] : [ld['@type']];
 
-		let seasonId: string | null = null;
-		let episodeId: string | null = null;
-		let subTitle: string | null = '';
+		if (types.includes('TVSeries')) {
+			const season = Array.isArray(ld.containsSeason) ? ld.containsSeason[0] : ld.containsSeason;
+			const episode = season?.episode;
 
-		const matches = /(?<seasonId>[\d]+)\s.(?<episodeId>[\d]+)\s(?<subTitle>.*)/.exec(
-			subTitleElement?.textContent ?? ''
-		);
-
-		if (matches?.groups) {
-			({ seasonId, episodeId, subTitle } = matches.groups);
-		}
-
-		if (seasonId) {
-			const season = parseInt(seasonId ?? '') || 0;
-			const number = parseInt(episodeId ?? '') || 0;
+			// Guard against stale metadata after an in-app (SPA) navigation: only trust
+			// the JSON-LD if it points at the episode the URL currently references.
+			if (!episode || (episode.url && !episode.url.includes(id))) {
+				return null;
+			}
 
 			return new EpisodeItem({
 				serviceId,
 				id,
-				title: subTitle,
-				season,
-				number,
+				title: episode.name ?? '',
+				season: parseInt(season?.seasonNumber ?? '') || 0,
+				number: parseInt(episode.episodeNumber ?? '') || 0,
 				show: {
 					serviceId,
-					title,
+					title: ld.name ?? '',
 				},
 			});
 		}
 
-		return new MovieItem({
-			serviceId,
-			id,
-			title,
-		});
+		if (types.includes('Movie')) {
+			if (ld.url && !ld.url.includes(id)) {
+				return null;
+			}
+
+			return new MovieItem({
+				serviceId,
+				id,
+				title: ld.name ?? '',
+				year: parseInt(ld.releaseYear ?? '') || 0,
+			});
+		}
+
+		return null;
 	}
 }
 

--- a/src/services/hotstar/HotstarParser.ts
+++ b/src/services/hotstar/HotstarParser.ts
@@ -26,6 +26,12 @@ interface HotstarLd {
 class _HotstarParser extends ScrobbleParser {
 	constructor() {
 		super(HotstarApi, {
+			// JioHotstar renders two <video> elements: the content player inside
+			// `#video-container` and pre-roll/mid-roll ads inside `#ad-video-container`.
+			// The default `video` selector grabs whichever comes first in the DOM (often
+			// the ad), so playback tracking attached to the ad element and dropped out
+			// when it ended. Scope to the content player so tracking is consistent.
+			videoPlayerSelector: '#video-container video',
 			watchingUrlRegex: /(?:movies|shows)\/.+\/(?<id>\d+)\//,
 		});
 	}


### PR DESCRIPTION
Restores reliable scrobbling on JioHotstar (post-rebrand). Three fixes.

## 1. Item detection — parse metadata instead of obfuscated DOM

Item detection relies entirely on the parser (there's no `getItem()` API for Hotstar). It used deeply-nested CSS selectors built on design-system class names (`ON_IMAGE`, `BUTTON1_MEDIUM`, …) that the rebrand removed — verified against the live site, they match **zero** elements. The player now ships build-hashed, obfuscated class names that change every deploy, so class/structure scraping is inherently fragile, and detection always returned `null`.

Parse stable sources instead:
- **JSON-LD** (`application/ld+json`) — `Movie` → name + releaseYear; `TVSeries` → show name, season, episode number, episode title. Clean and complete, but only present on a full page load.
- **Player title overlay** (fallback) — see fix #3.

The JSON-LD url is matched against the current content id **exactly** (the numeric id is extracted and compared, not via substring) so a shorter id can't collide with a longer one and stale metadata is rejected.

## 2. Playback tracking — follow the content player, not ads

JioHotstar renders two `<video>` elements: the content player in `#video-container` and pre-roll/mid-roll ads in `#ad-video-container`. The default `video` selector grabbed whichever came first (often the ad), so tracking attached to the ad and dropped out when it ended — making play/pause detection flaky. Scoped `videoPlayerSelector` to `#video-container video`.

## 3. Detect content across in-app (SPA) navigation

**Root cause of "changing episode/movie doesn't detect", debugged live:** the `Movie`/`TVSeries` JSON-LD node is only server-rendered on a full page load. JioHotstar advances between episodes (Next Episode / autoplay) via in-app SPA navigation, after which the node is **never re-injected** (confirmed absent 14s+ after navigation). `document.title`, `og:title`, and the URL's `episodeNumber`/`seasonId` query params are also stale or wrong (off by one) after in-app navigation. So the parser went blind once the user changed content without a full reload.

Fix — fall back to the **player title overlay**, which the player keeps in the DOM and updates on in-app navigation:
- `aria-label` of the form `"<show>, Season N, Episode N, <title>"`, guarded so the show matches the page `<h1>` (ignores up-next / recommendation rails)
- `"S<n> E<n> <title>"` overlay text as a further fallback

Content type (movie vs. show) is taken from the URL, which is always accurate.

Also **re-parse the item as soon as the URL's content id changes.** The base class only re-parses once the cached item is cleared, which is skipped when an item never matched on Trakt — so a stale item could otherwise stick across an in-app switch and block detection of the new content.

## Verification (live, logged-in site)

- Movie (full load): *The Dark Knight* (2008) via JSON-LD
- Episode (full load): *Curb Your Enthusiasm* S10 E2 "Side Sitting" via JSON-LD
- Episode after in-app **Next Episode** (JSON-LD absent): correctly detected S10 E3 "Artificial Fruit" and S10 E4 "…Mickey" via the overlay — with the parsed id always matching the URL id (no stale window). This is precisely the case that previously failed.
- Long pause (~1 min): the content `<video>` and its duration persist (no teardown); the item is preserved and resumes cleanly
- `#video-container video` resolves to the content player and ignores `#ad-video-container`
- `tsc --noEmit` and `biome check` clean; production build succeeds for Chrome and Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)