### PR TITLE
Add kino.watch domain for Kinopub

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 |      HBO Max      |    ✔️    |  ✔️  | -                                |
 |      Hotstar      |    ✔️    |  ❌  | -                                |
 |      Kijk.nl      |    ✔️    |  ❌  | -                                |
+|      Kinopub      |    ✔️    |  ✔️  | -                                |
 |       MUBI        |    ✔️    |  ✔️  | -                                |
 |      Netflix      |    ✔️    |  ✔️  | -                                |
 |        NRK        |    ✔️    |  ✔️  | -                                |

--- a/src/common/BrowserStorage.ts
+++ b/src/common/BrowserStorage.ts
@@ -14,7 +14,7 @@ import '@services';
 import { PartialDeep } from 'type-fest';
 import browser, { Manifest as WebExtManifest } from 'webextension-polyfill';
 
-export type StorageValues = StorageValuesV12;
+export type StorageValues = StorageValuesV13;
 export type StorageValuesOptions = StorageValuesOptionsV4;
 export type StorageValuesSyncOptions = StorageValuesSyncOptionsV3;
 
@@ -24,6 +24,10 @@ export type KinoPubAuthDetails = {
 	expires_in: number;
 	refresh_token: string;
 	created_at: number;
+};
+
+export type StorageValuesV13 = Omit<StorageValuesV12, 'version'> & {
+	version?: 13;
 };
 
 export type StorageValuesV12 = Omit<StorageValuesV11, 'version'> & {
@@ -244,7 +248,7 @@ export type BrowserStorageSetValues = Omit<StorageValues, 'options' | 'syncOptio
 export type BrowserStorageRemoveKey = Exclude<keyof StorageValues, 'options' | 'syncOptions'>;
 
 class _BrowserStorage {
-	readonly currentVersion = 12;
+	readonly currentVersion = 13;
 
 	isSyncAvailable: boolean;
 	options = {} as StorageValuesOptions;
@@ -429,6 +433,25 @@ class _BrowserStorage {
 			if (kinoPub && (kinoPub.scrobble || kinoPub.sync)) {
 				const hasPermission = await browser.permissions.contains({
 					origins: ['*://api.service-kp.com/*'],
+				});
+				if (!hasPermission) {
+					kinoPub.scrobble = false;
+					kinoPub.sync = false;
+					kinoPub.autoSync = false;
+
+					await this.doSet({ options }, true);
+				}
+			}
+		}
+
+		if (version < 13 && this.currentVersion >= 13) {
+			console.log('Upgrading to v13...');
+
+			const { options } = await this.get('options');
+			const kinoPub = options?.services?.['kino-pub'];
+			if (kinoPub && (kinoPub.scrobble || kinoPub.sync)) {
+				const hasPermission = await browser.permissions.contains({
+					origins: ['*://kino.watch/*', '*://*.kino.watch/*'],
 				});
 				if (!hasPermission) {
 					kinoPub.scrobble = false;

--- a/src/services/kino-pub/KinoPubApi.ts
+++ b/src/services/kino-pub/KinoPubApi.ts
@@ -9,11 +9,11 @@ import { EpisodeItem, MovieItem, ScrobbleItem, ScrobbleItemValues } from '@model
 import { KinoPubService } from '@/kino-pub/KinoPubService';
 import browser from 'webextension-polyfill';
 
-// Public Kodi/XBMC client credentials widely used by unofficial Kino.pub clients
+// Public Kodi/XBMC client credentials widely used by unofficial Kinopub clients
 const KINOPUB_CLIENT_ID = 'xbmc';
 const KINOPUB_CLIENT_SECRET = 'cgg3gtifu46urtfp2zp1nqtba0k2ezxh';
 
-/** Kino.pub titles are formatted as "Russian Title / Original Title". Extract the original. */
+/** Kinopub titles are formatted as "Russian Title / Original Title". Extract the original. */
 export const extractOriginalTitle = (title: string): string => title.split(' / ').at(-1) ?? title;
 
 export interface KinoPubHistoryItem {
@@ -261,7 +261,7 @@ class _KinoPubApi extends ServiceApi {
 			return true;
 		} catch (err) {
 			if (Shared.errors.validate(err)) {
-				Shared.errors.log('Kino.pub device flow failed', err);
+				Shared.errors.log('Kinopub device flow failed', err);
 			}
 			return false;
 		}

--- a/src/services/kino-pub/KinoPubService.ts
+++ b/src/services/kino-pub/KinoPubService.ts
@@ -2,9 +2,15 @@ import { Service } from '@models/Service';
 
 export const KinoPubService = new Service({
 	id: 'kino-pub',
-	name: 'Kino.pub',
-	homePage: 'https://kino.pub/',
-	hostPatterns: ['*://kino.pub/*', '*://*.kino.pub/*', '*://api.service-kp.com/*'],
+	name: 'Kinopub',
+	homePage: 'https://kino.watch/',
+	hostPatterns: [
+		'*://kino.watch/*',
+		'*://*.kino.watch/*',
+		'*://kino.pub/*',
+		'*://*.kino.pub/*',
+		'*://api.service-kp.com/*',
+	],
 	hasScrobbler: true,
 	hasSync: true,
 	hasAutoSync: true,


### PR DESCRIPTION
## Summary
- update Kinopub homepage to https://kino.watch/
- add kino.watch host patterns so the content script runs on the new domain
- keep kino.pub host patterns for backward compatibility

## API notes
- keep the existing Kinopub API host (`https://api.service-kp.com`) because the OAuth/device and history endpoints still respond there
- the device-flow endpoint returns `https://kino.watch/device` as the verification URL

## Checks
- pnpm tsc
- pnpm exec biome check src/services/kino-pub/KinoPubService.ts src/services/kino-pub/KinoPubApi.ts

Note: full `pnpm check` currently fails on ignored local file `.claude/settings.local.json`, unrelated to this PR.
