### PR TITLE
Add AniLibria scrobble and sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 | :---------------: | :------: | :--: | :------------------------------- |
 |   Amazon Prime    |    ✔️    |  ✔️  | Scrobbling only works in English |
 |       AMC+        |    ✔️    |  ❌  | -                                |
+|     AniLibria     |    ✔️    |  ✔️  | Synced watched dates are approximate |
 |       Crave       |    ✔️    |  ✔️  | -                                |
 |    Crunchyroll    |    ❌    |  ✔️  | -                                |
 |    discovery+     |    ✔️    |  ✔️  | -                                |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 | :---------------: | :------: | :--: | :------------------------------- |
 |   Amazon Prime    |    ✔️    |  ✔️  | Scrobbling only works in English |
 |       AMC+        |    ✔️    |  ❌  | -                                |
+|     AniLibria     |    ✔️    |  ✔️  | Synced watched dates are approximate |
 |     Apple TV      |    ✔️    |  ❌  | -                                |
 |       Crave       |    ✔️    |  ✔️  | -                                |
 |    Crunchyroll    |    ❌    |  ✔️  | -                                |

--- a/src/common/BrowserStorage.ts
+++ b/src/common/BrowserStorage.ts
@@ -28,6 +28,7 @@ export type KinoPubAuthDetails = {
 
 export type StorageValuesV12 = Omit<StorageValuesV11, 'version'> & {
 	version?: 12;
+	anilibriaFirstImportedAt?: Record<string, number>;
 };
 
 export type StorageValuesV11 = Omit<StorageValuesV10, 'version'> & {

--- a/src/services/anilibria/AnilibriaApi.ts
+++ b/src/services/anilibria/AnilibriaApi.ts
@@ -1,0 +1,236 @@
+import { ServiceApi } from '@apis/ServiceApi';
+import { Requests } from '@common/Requests';
+import { Shared } from '@common/Shared';
+import { Utils } from '@common/Utils';
+import { EpisodeItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
+import { AnilibriaService } from '@/anilibria/AnilibriaService';
+import browser from 'webextension-polyfill';
+
+interface AnilibriaProfileResponse {
+	nickname?: string;
+	login?: string;
+	email?: string;
+}
+
+interface AnilibriaName {
+	main?: string | null;
+	english?: string | null;
+	alternative?: string | null;
+}
+
+interface AnilibriaRelease {
+	id: number;
+	year?: number | null;
+	name?: AnilibriaName | null;
+	alias?: string | null;
+	poster?: {
+		thumbnail?: string | null;
+		preview?: string | null;
+		optimized?: {
+			thumbnail?: string | null;
+			preview?: string | null;
+		} | null;
+	} | null;
+}
+
+export interface AnilibriaEpisodeResponse {
+	id: string;
+	name?: string | null;
+	name_english?: string | null;
+	ordinal?: number | null;
+	duration?: number | null;
+	updated_at?: string | null;
+	release_id: number;
+	release?: AnilibriaRelease | null;
+}
+
+interface AnilibriaRawTimecode extends Array<string | number | boolean | null> {
+	0: string;
+	1: number;
+	2: boolean;
+}
+
+export interface AnilibriaHistoryItem {
+	releaseEpisodeId: string;
+	time: number;
+	isWatched: boolean;
+	firstImportedAt: number;
+}
+
+const HOST_URL = 'https://anilibria.top';
+
+const getBestTitle = (release?: AnilibriaRelease | null): string =>
+	release?.name?.english || release?.name?.main || release?.name?.alternative || '';
+
+const getImageUrl = (release?: AnilibriaRelease | null): string | undefined => {
+	const path =
+		release?.poster?.optimized?.thumbnail ||
+		release?.poster?.thumbnail ||
+		release?.poster?.optimized?.preview ||
+		release?.poster?.preview;
+	if (!path) {
+		return undefined;
+	}
+	return path.startsWith('http') ? path : `${HOST_URL}${path}`;
+};
+
+class _AnilibriaApi extends ServiceApi {
+	HOST_URL = HOST_URL;
+	private hasLoadedHistory = false;
+
+	constructor() {
+		super(AnilibriaService.id);
+	}
+
+	override reset(): void {
+		super.reset();
+		this.hasLoadedHistory = false;
+	}
+
+	async checkLogin(): Promise<boolean> {
+		try {
+			const responseText = await this.sendSessionRequest(
+				`${this.HOST_URL}/api/v1/accounts/users/me/profile`
+			);
+			const profile = JSON.parse(responseText) as AnilibriaProfileResponse;
+			this.session = {
+				profileName: profile.nickname ?? profile.login ?? profile.email ?? null,
+			};
+			return this.session.profileName !== null;
+		} catch (err) {
+			if (Shared.errors.validate(err)) {
+				Shared.errors.log(`Failed to check login for ${this.id}`, err);
+			}
+			this.session = null;
+			return false;
+		}
+	}
+
+	async loadHistoryItems(_cancelKey = 'default'): Promise<AnilibriaHistoryItem[]> {
+		if (this.hasLoadedHistory) {
+			this.hasReachedHistoryEnd = true;
+			return [];
+		}
+
+		const loggedIn = await this.checkLogin();
+		if (!loggedIn) {
+			this.hasReachedHistoryEnd = true;
+			return [];
+		}
+
+		const responseText = await this.sendSessionRequest(
+			`${this.HOST_URL}/api/v1/accounts/users/me/views/timecodes`
+		);
+		const rawTimecodes = JSON.parse(responseText) as AnilibriaRawTimecode[];
+		const { anilibriaFirstImportedAt = {} } = (await browser.storage.local.get(
+			'anilibriaFirstImportedAt'
+		)) as { anilibriaFirstImportedAt?: Record<string, number> };
+		const now = Utils.unix();
+		let hasNewImportedAt = false;
+
+		const historyItems = rawTimecodes
+			.map((timecode) => ({
+				releaseEpisodeId: timecode[0],
+				time: Number(timecode[1]) || 0,
+				isWatched: timecode[2] === true,
+				firstImportedAt: anilibriaFirstImportedAt[timecode[0]] ?? now,
+			}))
+			.filter((timecode) => timecode.releaseEpisodeId && timecode.isWatched);
+
+		for (const historyItem of historyItems) {
+			if (!anilibriaFirstImportedAt[historyItem.releaseEpisodeId]) {
+				anilibriaFirstImportedAt[historyItem.releaseEpisodeId] = historyItem.firstImportedAt;
+				hasNewImportedAt = true;
+			}
+		}
+		if (hasNewImportedAt) {
+			await browser.storage.local.set({ anilibriaFirstImportedAt });
+		}
+
+		this.hasLoadedHistory = true;
+		this.hasReachedHistoryEnd = true;
+		return historyItems.sort((a, b) => b.firstImportedAt - a.firstImportedAt);
+	}
+
+	isNewHistoryItem(historyItem: AnilibriaHistoryItem, lastSync: number): boolean {
+		return historyItem.firstImportedAt > lastSync;
+	}
+
+	getHistoryItemId(historyItem: AnilibriaHistoryItem): string {
+		return historyItem.releaseEpisodeId;
+	}
+
+	async convertHistoryItems(historyItems: AnilibriaHistoryItem[]): Promise<ScrobbleItem[]> {
+		const items = await Promise.all(
+			historyItems.map(async (historyItem) => {
+				const episode = await this.getEpisode(historyItem.releaseEpisodeId);
+				return this.convertEpisode(episode, historyItem.firstImportedAt, 100);
+			})
+		);
+		return items.filter((item): item is ScrobbleItem => item !== null);
+	}
+
+	updateItemFromHistory(item: ScrobbleItemValues, historyItem: AnilibriaHistoryItem): void {
+		item.watchedAt = item.watchedAt ?? historyItem.firstImportedAt;
+		item.progress = 100;
+	}
+
+	async getEpisode(
+		releaseEpisodeId: string,
+		cancelKey = 'default'
+	): Promise<AnilibriaEpisodeResponse> {
+		const responseText = await Requests.send({
+			url: `${this.HOST_URL}/api/v1/anime/releases/episodes/${releaseEpisodeId}`,
+			method: 'GET',
+			cancelKey,
+		});
+		return JSON.parse(responseText) as AnilibriaEpisodeResponse;
+	}
+
+	private async sendSessionRequest(url: string): Promise<string> {
+		const response = await fetch(url, {
+			method: 'GET',
+			credentials: 'include',
+		});
+		const text = await response.text();
+		if (!response.ok) {
+			throw new Error(text || `AniLibria request failed with status ${response.status}`);
+		}
+		return text;
+	}
+
+	convertEpisode(
+		episode: AnilibriaEpisodeResponse,
+		watchedAt?: number,
+		progress?: number
+	): ScrobbleItem | null {
+		if (!episode.release) {
+			return null;
+		}
+
+		const showTitle = getBestTitle(episode.release);
+		if (!showTitle) {
+			return null;
+		}
+
+		return new EpisodeItem({
+			serviceId: this.id,
+			id: episode.id,
+			title: episode.name_english || episode.name || `Episode ${episode.ordinal ?? ''}`.trim(),
+			season: 1,
+			number: episode.ordinal ?? 0,
+			isAbsolute: true,
+			year: episode.release.year ?? undefined,
+			watchedAt,
+			progress,
+			imageUrl: getImageUrl(episode.release),
+			show: {
+				serviceId: this.id,
+				id: episode.release.id.toString(),
+				title: showTitle,
+			},
+		});
+	}
+}
+
+export const AnilibriaApi = new _AnilibriaApi();

--- a/src/services/anilibria/AnilibriaApi.ts
+++ b/src/services/anilibria/AnilibriaApi.ts
@@ -4,7 +4,6 @@ import { Shared } from '@common/Shared';
 import { Utils } from '@common/Utils';
 import { EpisodeItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
 import { AnilibriaService } from '@/anilibria/AnilibriaService';
-import browser from 'webextension-polyfill';
 
 interface AnilibriaProfileResponse {
 	nickname?: string;
@@ -44,11 +43,7 @@ export interface AnilibriaEpisodeResponse {
 	release?: AnilibriaRelease | null;
 }
 
-interface AnilibriaRawTimecode extends Array<string | number | boolean | null> {
-	0: string;
-	1: number;
-	2: boolean;
-}
+type AnilibriaRawTimecode = [string, number, boolean];
 
 export interface AnilibriaHistoryItem {
 	releaseEpisodeId: string;
@@ -87,10 +82,11 @@ class _AnilibriaApi extends ServiceApi {
 		this.hasLoadedHistory = false;
 	}
 
-	async checkLogin(): Promise<boolean> {
+	async checkLogin(cancelKey = 'default'): Promise<boolean> {
 		try {
 			const responseText = await this.sendSessionRequest(
-				`${this.HOST_URL}/api/v1/accounts/users/me/profile`
+				`${this.HOST_URL}/api/v1/accounts/users/me/profile`,
+				cancelKey
 			);
 			const profile = JSON.parse(responseText) as AnilibriaProfileResponse;
 			this.session = {
@@ -106,27 +102,24 @@ class _AnilibriaApi extends ServiceApi {
 		}
 	}
 
-	async loadHistoryItems(_cancelKey = 'default'): Promise<AnilibriaHistoryItem[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<AnilibriaHistoryItem[]> {
 		if (this.hasLoadedHistory) {
 			this.hasReachedHistoryEnd = true;
 			return [];
 		}
 
-		const loggedIn = await this.checkLogin();
+		const loggedIn = await this.checkLogin(cancelKey);
 		if (!loggedIn) {
-			this.hasReachedHistoryEnd = true;
-			return [];
+			throw new Error('Invalid session');
 		}
 
 		const responseText = await this.sendSessionRequest(
-			`${this.HOST_URL}/api/v1/accounts/users/me/views/timecodes`
+			`${this.HOST_URL}/api/v1/accounts/users/me/views/timecodes`,
+			cancelKey
 		);
 		const rawTimecodes = JSON.parse(responseText) as AnilibriaRawTimecode[];
-		const { anilibriaFirstImportedAt = {} } = (await browser.storage.local.get(
-			'anilibriaFirstImportedAt'
-		)) as { anilibriaFirstImportedAt?: Record<string, number> };
+		const { anilibriaFirstImportedAt = {} } = await Shared.storage.get('anilibriaFirstImportedAt');
 		const now = Utils.unix();
-		let hasNewImportedAt = false;
 
 		const historyItems = rawTimecodes
 			.map((timecode) => ({
@@ -137,14 +130,17 @@ class _AnilibriaApi extends ServiceApi {
 			}))
 			.filter((timecode) => timecode.releaseEpisodeId && timecode.isWatched);
 
-		for (const historyItem of historyItems) {
-			if (!anilibriaFirstImportedAt[historyItem.releaseEpisodeId]) {
-				anilibriaFirstImportedAt[historyItem.releaseEpisodeId] = historyItem.firstImportedAt;
-				hasNewImportedAt = true;
-			}
-		}
-		if (hasNewImportedAt) {
-			await browser.storage.local.set({ anilibriaFirstImportedAt });
+		const updatedFirstImportedAt = Object.fromEntries(
+			historyItems.map((historyItem) => [historyItem.releaseEpisodeId, historyItem.firstImportedAt])
+		);
+		if (
+			Object.keys(anilibriaFirstImportedAt).length !== Object.keys(updatedFirstImportedAt).length ||
+			historyItems.some(
+				(historyItem) =>
+					anilibriaFirstImportedAt[historyItem.releaseEpisodeId] !== historyItem.firstImportedAt
+			)
+		) {
+			await Shared.storage.set({ anilibriaFirstImportedAt: updatedFirstImportedAt }, true);
 		}
 
 		this.hasLoadedHistory = true;
@@ -161,13 +157,16 @@ class _AnilibriaApi extends ServiceApi {
 	}
 
 	async convertHistoryItems(historyItems: AnilibriaHistoryItem[]): Promise<ScrobbleItem[]> {
-		const items = await Promise.all(
-			historyItems.map(async (historyItem) => {
-				const episode = await this.getEpisode(historyItem.releaseEpisodeId);
-				return this.convertEpisode(episode, historyItem.firstImportedAt, 100);
-			})
-		);
-		return items.filter((item): item is ScrobbleItem => item !== null);
+		const items: ScrobbleItem[] = [];
+		for (const historyItem of historyItems) {
+			const episode = await this.getEpisode(historyItem.releaseEpisodeId);
+			const item = this.convertEpisode(episode, historyItem.firstImportedAt, 100);
+			if (!item) {
+				throw new Error(`Could not convert AniLibria episode ${historyItem.releaseEpisodeId}`);
+			}
+			items.push(item);
+		}
+		return items;
 	}
 
 	updateItemFromHistory(item: ScrobbleItemValues, historyItem: AnilibriaHistoryItem): void {
@@ -187,16 +186,12 @@ class _AnilibriaApi extends ServiceApi {
 		return JSON.parse(responseText) as AnilibriaEpisodeResponse;
 	}
 
-	private async sendSessionRequest(url: string): Promise<string> {
-		const response = await fetch(url, {
+	private sendSessionRequest(url: string, cancelKey: string): Promise<string> {
+		return Requests.send({
+			url,
 			method: 'GET',
-			credentials: 'include',
+			cancelKey,
 		});
-		const text = await response.text();
-		if (!response.ok) {
-			throw new Error(text || `AniLibria request failed with status ${response.status}`);
-		}
-		return text;
 	}
 
 	convertEpisode(

--- a/src/services/anilibria/AnilibriaParser.ts
+++ b/src/services/anilibria/AnilibriaParser.ts
@@ -1,0 +1,26 @@
+import { ScrobbleParser } from '@common/ScrobbleParser';
+import { ScrobbleItem } from '@models/Item';
+import { AnilibriaApi } from '@/anilibria/AnilibriaApi';
+
+class _AnilibriaParser extends ScrobbleParser {
+	constructor() {
+		super(AnilibriaApi, {
+			watchingUrlRegex: /\/anime\/video\/episode\/(?<id>[^/?#]+)/,
+		});
+	}
+
+	protected override async parseItemFromApi(): Promise<ScrobbleItem | null> {
+		const id = this.parseItemIdFromUrl();
+		if (!id) {
+			return null;
+		}
+		const episode = await AnilibriaApi.getEpisode(id);
+		return AnilibriaApi.convertEpisode(episode);
+	}
+
+	parseItemFromDom(): ScrobbleItem | null {
+		return null;
+	}
+}
+
+export const AnilibriaParser = new _AnilibriaParser();

--- a/src/services/anilibria/AnilibriaService.ts
+++ b/src/services/anilibria/AnilibriaService.ts
@@ -1,0 +1,15 @@
+import { Service } from '@models/Service';
+
+export const AnilibriaService = new Service({
+	id: 'anilibria',
+	name: 'AniLibria',
+	homePage: 'https://anilibria.top/',
+	hostPatterns: ['*://anilibria.top/*'],
+	hasScrobbler: true,
+	hasSync: true,
+	hasAutoSync: true,
+	limitations: [
+		'Synced watched dates use the first import time when AniLibria does not provide a watched date',
+	],
+	loginPage: 'https://anilibria.top/app/auth/login',
+});

--- a/src/services/anilibria/anilibria.ts
+++ b/src/services/anilibria/anilibria.ts
@@ -1,0 +1,4 @@
+import { init } from '@service';
+import '@/anilibria/AnilibriaParser';
+
+void init('anilibria');


### PR DESCRIPTION
## Summary
- add support for AniLibria, a Russian anime streaming service, on anilibria.top
- add both playback scrobbling and account history sync for AniLibria episodes
- sync watched AniLibria account timecodes through the existing browser session
- preserve first-import timestamps as approximate watched dates when AniLibria does not provide real watched dates

## Notes
- keeps the approximate watched-date cache service-local in extension local storage
- limits code changes to AniLibria service files plus the README service table

## Validation
- pnpm check
- pnpm build-dev
- fast manual AniLibria smoke test