### PR TITLE
Support Netflix playback progress for history sync

### DIFF
--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -220,10 +220,14 @@ export abstract class ServiceApi {
 					hasReachedLastSyncDate;
 			} while (!hasReachedEnd && itemsToLoad > 0);
 			if (historyItems.length > 0) {
+				const preparedHistoryItems = await this.prepareHistoryItems(historyItems);
+				if (preparedHistoryItems.length !== historyItems.length) {
+					throw new Error('prepareHistoryItems() must preserve the number of history items');
+				}
 				const tmpItems: (ScrobbleItem | null)[] = [];
 				const historyItemsToConvert = [];
 
-				for (const historyItem of historyItems) {
+				for (const historyItem of preparedHistoryItems) {
 					const historyItemId = `${this.id}_${this.getHistoryItemId(historyItem)}`;
 					const itemId = caches.historyItemsToItems.get(historyItemId);
 					if (itemId) {
@@ -257,7 +261,7 @@ export abstract class ServiceApi {
 					items = tmpItems as ScrobbleItem[];
 				}
 
-				for (const [index, historyItem] of historyItems.entries()) {
+				for (const [index, historyItem] of preparedHistoryItems.entries()) {
 					const historyItemId = `${this.id}_${this.getHistoryItemId(historyItem)}`;
 					const item = items[index];
 					const itemDatabaseId = item.getDatabaseId();
@@ -316,6 +320,14 @@ export abstract class ServiceApi {
 	getHistoryItemId(_historyItem: unknown): string {
 		Shared.errors.error('getHistoryItemId() is not implemented in this service!', new Error());
 		return '';
+	}
+
+	/**
+	 * Enriches history items before cached items and new items take separate paths.
+	 * Implementations must preserve the number and order of the supplied items.
+	 */
+	prepareHistoryItems(historyItems: unknown[]): Promisable<unknown[]> {
+		return historyItems;
 	}
 
 	/**

--- a/src/services/netflix/NetflixApi.ts
+++ b/src/services/netflix/NetflixApi.ts
@@ -1,4 +1,10 @@
 import { NetflixService } from '@/netflix/NetflixService';
+import {
+	getNetflixHistoryProgress,
+	mergeNetflixHistoryProgress,
+	NetflixHistoryProgress,
+	NetflixPlaybackMetadata,
+} from '@/netflix/NetflixProgress';
 import { ServiceApi, ServiceApiSession } from '@apis/ServiceApi';
 import { Requests } from '@common/Requests';
 import { ScriptInjector } from '@common/ScriptInjector';
@@ -66,10 +72,8 @@ export interface NetflixHistoryResponse {
 
 export type NetflixHistoryItem = NetflixHistoryEpisodeItem | NetflixHistoryMovieItem;
 
-export interface NetflixHistoryEpisodeItem {
-	bookmark: number;
+export interface NetflixHistoryEpisodeItem extends NetflixHistoryProgress {
 	date: number;
-	duration: number;
 	episodeTitle: string;
 	movieID: number;
 	series: number;
@@ -77,10 +81,8 @@ export interface NetflixHistoryEpisodeItem {
 	title: string;
 }
 
-export interface NetflixHistoryMovieItem {
-	bookmark: number;
+export interface NetflixHistoryMovieItem extends NetflixHistoryProgress {
 	date: number;
-	duration: number;
 	movieID: number;
 	title: string;
 }
@@ -136,7 +138,7 @@ export interface NetflixSingleMetadataItem {
 	video: NetflixMetadataShow | NetflixMetadataMovie;
 }
 
-export interface NetflixMetadataGeneric {
+export interface NetflixMetadataGeneric extends NetflixPlaybackMetadata {
 	id: number;
 	title: string;
 	year: number;
@@ -154,7 +156,7 @@ export interface NetflixMetadataShowSeason {
 	seq: number;
 }
 
-export interface NetflixMetadataShowEpisode {
+export interface NetflixMetadataShowEpisode extends NetflixPlaybackMetadata {
 	id: number;
 	seq: number;
 	title: string;
@@ -201,6 +203,11 @@ class _NetflixApi extends ServiceApi {
 		this.ACTIVATE_URL = `${this.HOST_URL}/settings/viewed/`;
 
 		this.isActivated = false;
+	}
+
+	reset(): void {
+		super.reset();
+		this.metadataCache.clear();
 	}
 
 	private async fetchActivatePage(maxRetries = 3): Promise<string> {
@@ -324,25 +331,20 @@ class _NetflixApi extends ServiceApi {
 		return historyItem.movieID.toString();
 	}
 
-	async convertHistoryItems(historyItems: NetflixHistoryItem[]) {
-		const historyItemsWithMetadata = await this.getHistoryMetadata(historyItems);
-		return historyItemsWithMetadata.map((historyItem) => this.parseHistoryItem(historyItem));
+	prepareHistoryItems(historyItems: NetflixHistoryItem[]) {
+		return this.getHistoryMetadata(historyItems);
+	}
+
+	convertHistoryItems(historyItems: NetflixHistoryItemWithMetadata[]) {
+		return historyItems.map((historyItem) => this.parseHistoryItem(historyItem));
 	}
 
 	updateItemFromHistory(
 		item: ScrobbleItemValues,
-		historyItem: NetflixHistoryItem
+		historyItem: NetflixHistoryItemWithMetadata
 	): Promisable<void> {
 		item.watchedAt = Utils.unix(historyItem.date);
-
-		// Handle missing bookmark/duration data with fallback
-		// If no bookmark/duration data, assume 100% progress since item appears in viewing history
-		const bookmark = historyItem.bookmark ?? 0;
-		const duration = historyItem.duration ?? 1;
-		const hasValidData = historyItem.bookmark !== undefined && historyItem.duration !== undefined;
-		const calculatedProgress = hasValidData ? Math.ceil((bookmark / duration) * 100) : 100;
-
-		item.progress = calculatedProgress;
+		item.progress = getNetflixHistoryProgress(historyItem.bookmark, historyItem.duration);
 	}
 
 	/**
@@ -413,6 +415,7 @@ class _NetflixApi extends ServiceApi {
 						if (episode) {
 							combinedItem = {
 								...historyItem,
+								...mergeNetflixHistoryProgress(historyItem, episode),
 								releaseYear: video.year,
 								seriesTitle: video.title || historyItem.seriesTitle,
 								episodeTitle: episode.title || historyItem.episodeTitle,
@@ -434,6 +437,7 @@ class _NetflixApi extends ServiceApi {
 				if (video && video.type === 'movie') {
 					combinedItem = {
 						...historyItem,
+						...mergeNetflixHistoryProgress(historyItem, video),
 						releaseYear: video.year,
 						title: video.title || historyItem.title,
 						summary: { id: historyItem.movieID },
@@ -505,12 +509,7 @@ class _NetflixApi extends ServiceApi {
 		const id = historyItem.movieID.toString();
 		const year = historyItem.releaseYear;
 		const watchedAt = Utils.unix(historyItem.date);
-		// Handle missing bookmark/duration data with fallback
-		// If no bookmark/duration data, assume 100% progress since item appears in viewing history
-		const bookmark = historyItem.bookmark ?? 0;
-		const duration = historyItem.duration ?? 1;
-		const hasValidData = historyItem.bookmark !== undefined && historyItem.duration !== undefined;
-		const progress = hasValidData ? Math.ceil((bookmark / duration) * 100) : 100;
+		const progress = getNetflixHistoryProgress(historyItem.bookmark, historyItem.duration);
 
 		if (this.isShow(historyItem)) {
 			const title = historyItem.seriesTitle.trim();

--- a/src/services/netflix/NetflixProgress.ts
+++ b/src/services/netflix/NetflixProgress.ts
@@ -1,0 +1,62 @@
+/**
+ * The configured completion threshold can be 0, so unknown progress cannot use 0 as a fallback.
+ * A negative value remains hidden and unselectable in both manual and automatic history sync.
+ */
+export const UNKNOWN_NETFLIX_PROGRESS = -1;
+
+export interface NetflixHistoryProgress {
+	bookmark?: number;
+	duration?: number;
+}
+
+export interface NetflixPlaybackMetadata {
+	bookmark?: {
+		offset?: number | null;
+	} | null;
+	runtime?: number | null;
+}
+
+export const calculateNetflixProgress = (
+	bookmark: number | null | undefined,
+	duration: number | null | undefined
+): number | undefined => {
+	if (
+		typeof bookmark !== 'number' ||
+		!Number.isFinite(bookmark) ||
+		typeof duration !== 'number' ||
+		!Number.isFinite(duration) ||
+		duration <= 0
+	) {
+		return;
+	}
+
+	const progress = Math.min(100, Math.max(0, (bookmark / duration) * 100));
+
+	// Item values are stored with two decimal places. Floor to that precision so rounding cannot
+	// promote a value just below the user's completion threshold to the threshold itself.
+	return Math.floor(progress * 100) / 100;
+};
+
+export const getNetflixHistoryProgress = (
+	bookmark: number | null | undefined,
+	duration: number | null | undefined
+): number => calculateNetflixProgress(bookmark, duration) ?? UNKNOWN_NETFLIX_PROGRESS;
+
+export const mergeNetflixHistoryProgress = (
+	historyProgress: NetflixHistoryProgress,
+	metadata: NetflixPlaybackMetadata
+): NetflixHistoryProgress => {
+	const bookmark = metadata.bookmark?.offset;
+	const duration = metadata.runtime;
+	if (
+		typeof bookmark === 'number' &&
+		typeof duration === 'number' &&
+		calculateNetflixProgress(bookmark, duration) !== undefined
+	) {
+		return { bookmark, duration };
+	}
+	return {
+		bookmark: historyProgress.bookmark,
+		duration: historyProgress.duration,
+	};
+};


### PR DESCRIPTION
I finally found a way to get proper progress (percentage watched) with Netflix, so not everything is assumed fully watched no matter how short you actually watched. Turns out the account metadata API (that we already use) holds that information, so the fix is quiet small. Seems like you can also get progress from their GraphQL API, but it didn't seem reliable enough to be worth it. 

Either way, I've tested it and it works great. I bet there are some issues that this should fix, but I'm too lazy right now to search for them. 