### PR TITLE
support new trakt app url for corrections

### DIFF
--- a/src/components/CorrectionDialog.tsx
+++ b/src/components/CorrectionDialog.tsx
@@ -247,23 +247,49 @@ export const CorrectionDialog = (): JSX.Element => {
 
 	const validUrlRegex =
 		/\/shows\/(?<show>[\w-]+)\/seasons\/(?<season>[\w-]+)\/episodes\/(?<episode>[\w-]+)|\/movies\/(?<movie>[\w-]+)/;
+	const validAppUrlRegex =
+		/\/shows\/(?<show>[\w-]+)\?.*(season=(?<season>[\w-]+)|episode=(?<episode>[\w-]+)|\&){3,}|\/movies\/(?<movie>[\w-]+)/;
 
 	const isValidUrl = (url: string): boolean => {
-		return !!validUrlRegex.exec(url);
+		return url.startsWith('https://app.trakt.tv')
+			? !!validAppUrlRegex.exec(url) && url.includes('?')
+			: !!validUrlRegex.exec(url);
 	};
 
 	const cleanUrl = (url: string): string => {
-		const matches = validUrlRegex.exec(url);
-		if (!matches?.groups) {
-			return '';
+		if (url.startsWith('https://app.trakt.tv')) {
+			const matches = validAppUrlRegex.exec(url);
+
+			if (!matches?.groups) {
+				return '';
+			}
+			const { show, movie } = matches.groups;
+
+			const searchParams = new URLSearchParams(url.split('?')[1]);
+			const season = searchParams.get('season');
+			const episode = searchParams.get('episode');
+
+			if (show && season && episode) {
+				return `/shows/${show}/seasons/${season}/episodes/${episode}`;
+			}
+
+			if (movie) {
+				return `/movies/${movie}`;
+			}
+		} else {
+			const matches = validUrlRegex.exec(url);
+			if (!matches?.groups) {
+				return '';
+			}
+			const { show, season, episode, movie } = matches.groups;
+			if (show && season && episode) {
+				return `/shows/${show}/seasons/${season}/episodes/${episode}`;
+			}
+			if (movie) {
+				return `/movies/${movie}`;
+			}
 		}
-		const { show, season, episode, movie } = matches.groups;
-		if (show && season && episode) {
-			return `/shows/${show}/seasons/${season}/episodes/${episode}`;
-		}
-		if (movie) {
-			return `/movies/${movie}`;
-		}
+
 		return '';
 	};
 

--- a/src/components/CorrectionDialog.tsx
+++ b/src/components/CorrectionDialog.tsx
@@ -247,8 +247,7 @@ export const CorrectionDialog = (): JSX.Element => {
 
 	const validUrlRegex =
 		/\/shows\/(?<show>[\w-]+)\/seasons\/(?<season>[\w-]+)\/episodes\/(?<episode>[\w-]+)|\/movies\/(?<movie>[\w-]+)/;
-	const validAppUrlRegex =
-		/\/shows\/(?<show>[\w-]+)|\/movies\/(?<movie>[\w-]+)/;
+	const validAppUrlRegex = /\/shows\/(?<show>[\w-]+)|\/movies\/(?<movie>[\w-]+)/;
 
 	const isValidUrl = (url: string): boolean => cleanUrl(url) !== '';
 

--- a/src/components/CorrectionDialog.tsx
+++ b/src/components/CorrectionDialog.tsx
@@ -248,31 +248,23 @@ export const CorrectionDialog = (): JSX.Element => {
 	const validUrlRegex =
 		/\/shows\/(?<show>[\w-]+)\/seasons\/(?<season>[\w-]+)\/episodes\/(?<episode>[\w-]+)|\/movies\/(?<movie>[\w-]+)/;
 	const validAppUrlRegex =
-		/\/shows\/(?<show>[\w-]+)\?.*(season=(?<season>[\w-]+)|episode=(?<episode>[\w-]+)|\&){3,}|\/movies\/(?<movie>[\w-]+)/;
+		/\/shows\/(?<show>[\w-]+)|\/movies\/(?<movie>[\w-]+)/;
 
-	const isValidUrl = (url: string): boolean => {
-		return url.startsWith('https://app.trakt.tv')
-			? !!validAppUrlRegex.exec(url) && url.includes('?')
-			: !!validUrlRegex.exec(url);
-	};
+	const isValidUrl = (url: string): boolean => cleanUrl(url) !== '';
 
 	const cleanUrl = (url: string): string => {
 		if (url.startsWith('https://app.trakt.tv')) {
 			const matches = validAppUrlRegex.exec(url);
-
 			if (!matches?.groups) {
 				return '';
 			}
 			const { show, movie } = matches.groups;
-
 			const searchParams = new URLSearchParams(url.split('?')[1]);
 			const season = searchParams.get('season');
 			const episode = searchParams.get('episode');
-
 			if (show && season && episode) {
 				return `/shows/${show}/seasons/${season}/episodes/${episode}`;
 			}
-
 			if (movie) {
 				return `/movies/${movie}`;
 			}


### PR DESCRIPTION
Trakt.tv changed the URL structure in their new web UI.
Seasons and episodes are now passed as search parameters instead of being part of the URL path.

Old pattern: https://trakt.tv/shows/dark/seasons/1/episodes/1
New pattern: https://app.trakt.tv/shows/dark?season=1&view=episode&episode=1

Search parameters can appear in any order and may include optional parameters like "view" or "mode". This made regex matching unreliable.