### PR TITLE
Add Apple TV web scrobbler

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,36 +67,38 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 <!-- services-start -->
 <!-- Update this section with `npx trakt-tools dev update-readme` -->
 
-| Streaming Service | Scrobble | Sync | Limitations                      |
-| :---------------: | :------: | :--: | :------------------------------- |
-|   Amazon Prime    |    ✔️    |  ✔️  | Scrobbling only works in English |
-|       AMC+        |    ✔️    |  ❌  | -                                |
-|       Crave       |    ✔️    |  ✔️  | -                                |
-|    Crunchyroll    |    ❌    |  ✔️  | -                                |
-|    discovery+     |    ✔️    |  ✔️  | -                                |
-|      Disney+      |    ✔️    |  ❌  | -                                |
-|        Go3        |    ✔️    |  ❌  | -                                |
-|     GoPlay BE     |    ✔️    |  ❌  | -                                |
-|      HBO Go       |    ✔️    |  ❌  | -                                |
-|      HBO Max      |    ✔️    |  ✔️  | -                                |
-|      Hotstar      |    ✔️    |  ❌  | -                                |
-|      Kijk.nl      |    ✔️    |  ❌  | -                                |
-|       MUBI        |    ✔️    |  ✔️  | -                                |
-|      Netflix      |    ✔️    |  ✔️  | -                                |
-|        NRK        |    ✔️    |  ✔️  | -                                |
-|     Player.pl     |    ✔️    |  ❌  | -                                |
-|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                                |
-|    SkyShowtime    |    ✔️    |  ❌  | -                                |
-|       Star+       |    ✔️    |  ❌  | -                                |
-|    Streamz BE     |    ✔️    |  ❌  | -                                |
-|      Stremio      |    ✔️    |  ❌  | -                                |
-|      Tet TV+      |    ✔️    |  ❌  | -                                |
-|     TV 2 PLAY     |    ✔️    |  ✔️  | -                                |
-|      Viaplay      |    ✔️    |  ✔️  | -                                |
-|       Vidio       |    ✔️    |  ❌  | -                                |
-|     VRTNu BE      |    ✔️    |  ❌  | -                                |
-|     VTMGo BE      |    ✔️    |  ❌  | -                                |
-|    Wakanim.tv     |    ✔️    |  ❌  | -                                |
+| Streaming Service | Scrobble | Sync | Limitations                                                      |
+| :---------------: | :------: | :--: | :--------------------------------------------------------------- |
+|   Amazon Prime    |    ✔️    |  ✔️  | -                                                                |
+|       AMC+        |    ✔️    |  ❌  | -                                                                |
+|     Apple TV      |    ✔️    |  ❌  | - Live sports, trailers, extras, and previews are not scrobbled. |
+|       Crave       |    ✔️    |  ✔️  | -                                                                |
+|    Crunchyroll    |    ❌    |  ✔️  | -                                                                |
+|    discovery+     |    ✔️    |  ✔️  | -                                                                |
+|      Disney+      |    ✔️    |  ❌  | -                                                                |
+|        Go3        |    ✔️    |  ❌  | -                                                                |
+|     GoPlay BE     |    ✔️    |  ❌  | -                                                                |
+|      HBO Go       |    ✔️    |  ❌  | -                                                                |
+|      HBO Max      |    ✔️    |  ✔️  | -                                                                |
+|      Hotstar      |    ✔️    |  ❌  | -                                                                |
+|      Kijk.nl      |    ✔️    |  ❌  | -                                                                |
+|     Kino.pub      |    ✔️    |  ✔️  | -                                                                |
+|       MUBI        |    ✔️    |  ✔️  | -                                                                |
+|      Netflix      |    ✔️    |  ✔️  | -                                                                |
+|        NRK        |    ✔️    |  ✔️  | -                                                                |
+|     Player.pl     |    ✔️    |  ❌  | -                                                                |
+|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                                                                |
+|    SkyShowtime    |    ✔️    |  ❌  | -                                                                |
+|       Star+       |    ✔️    |  ❌  | -                                                                |
+|    Streamz BE     |    ✔️    |  ❌  | -                                                                |
+|      stremio      |    ✔️    |  ❌  | -                                                                |
+|      Tet TV+      |    ✔️    |  ❌  | -                                                                |
+|     TV 2 Play     |    ✔️    |  ✔️  | -                                                                |
+|      Viaplay      |    ✔️    |  ✔️  | -                                                                |
+|       Vidio       |    ✔️    |  ❌  | -                                                                |
+|    VRT Max BE     |    ✔️    |  ❌  | -                                                                |
+|     VTMGo BE      |    ✔️    |  ❌  | -                                                                |
+|    Wakanim.tv     |    ✔️    |  ❌  | -                                                                |
 
 <!-- services-end -->
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Extension will be enabled until you restart Firefox.
 - [What is Universal Trakt Scrobbler?](#what-is-universal-trakt-scrobbler)
 - [Why do I need this extension?](#why-do-i-need-this-extension)
 - [Which streaming services are supported?](#which-streaming-services-are-supported)
+  - [Apple TV](#apple-tv)
 - [How does the extension work?](#how-does-the-extension-work)
 - [Known Issues](#known-issues)
 - [Other Problems](#other-problems)
@@ -101,6 +102,14 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 |    Wakanim.tv     |    ✔️    |  ❌  | -                                                                |
 
 <!-- services-end -->
+
+#### Apple TV
+
+Apple TV support is scrobble-only; historical watch synchronization is not available. Enable Apple TV in the extension options and approve the optional `*://*.tv.apple.com/*` permission when prompted.
+
+The scrobbler supports on-demand movies and TV episodes played on `tv.apple.com`, including playback started from title pages, Continue Watching, featured content, and other homepage shelves. It follows in-page navigation and autoplay transitions even when Apple TV keeps the browser URL on the homepage.
+
+Live sports, trailers, extras, previews, promotional background videos, and other non-feature content are intentionally excluded.
 
 ### How does the extension work?
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Extension will be enabled until you restart Firefox.
 - [What is Universal Trakt Scrobbler?](#what-is-universal-trakt-scrobbler)
 - [Why do I need this extension?](#why-do-i-need-this-extension)
 - [Which streaming services are supported?](#which-streaming-services-are-supported)
-  - [Apple TV](#apple-tv)
 - [How does the extension work?](#how-does-the-extension-work)
 - [Known Issues](#known-issues)
 - [Other Problems](#other-problems)
@@ -68,48 +67,39 @@ If you want to scrobble / sync from Netflix, this is the only Trakt.tv [plugin](
 <!-- services-start -->
 <!-- Update this section with `npx trakt-tools dev update-readme` -->
 
-| Streaming Service | Scrobble | Sync | Limitations                                                      |
-| :---------------: | :------: | :--: | :--------------------------------------------------------------- |
-|   Amazon Prime    |    ✔️    |  ✔️  | -                                                                |
-|       AMC+        |    ✔️    |  ❌  | -                                                                |
-|     Apple TV      |    ✔️    |  ❌  | - Live sports, trailers, extras, and previews are not scrobbled. |
-|       Crave       |    ✔️    |  ✔️  | -                                                                |
-|    Crunchyroll    |    ❌    |  ✔️  | -                                                                |
-|    discovery+     |    ✔️    |  ✔️  | -                                                                |
-|      Disney+      |    ✔️    |  ❌  | -                                                                |
-|        Go3        |    ✔️    |  ❌  | -                                                                |
-|     GoPlay BE     |    ✔️    |  ❌  | -                                                                |
-|      HBO Go       |    ✔️    |  ❌  | -                                                                |
-|      HBO Max      |    ✔️    |  ✔️  | -                                                                |
-|      Hotstar      |    ✔️    |  ❌  | -                                                                |
-|      Kijk.nl      |    ✔️    |  ❌  | -                                                                |
-|     Kino.pub      |    ✔️    |  ✔️  | -                                                                |
-|       MUBI        |    ✔️    |  ✔️  | -                                                                |
-|      Netflix      |    ✔️    |  ✔️  | -                                                                |
-|        NRK        |    ✔️    |  ✔️  | -                                                                |
-|     Player.pl     |    ✔️    |  ❌  | -                                                                |
-|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                                                                |
-|    SkyShowtime    |    ✔️    |  ❌  | -                                                                |
-|       Star+       |    ✔️    |  ❌  | -                                                                |
-|    Streamz BE     |    ✔️    |  ❌  | -                                                                |
-|      stremio      |    ✔️    |  ❌  | -                                                                |
-|      Tet TV+      |    ✔️    |  ❌  | -                                                                |
-|     TV 2 Play     |    ✔️    |  ✔️  | -                                                                |
-|      Viaplay      |    ✔️    |  ✔️  | -                                                                |
-|       Vidio       |    ✔️    |  ❌  | -                                                                |
-|    VRT Max BE     |    ✔️    |  ❌  | -                                                                |
-|     VTMGo BE      |    ✔️    |  ❌  | -                                                                |
-|    Wakanim.tv     |    ✔️    |  ❌  | -                                                                |
+| Streaming Service | Scrobble | Sync | Limitations                      |
+| :---------------: | :------: | :--: | :------------------------------- |
+|   Amazon Prime    |    ✔️    |  ✔️  | Scrobbling only works in English |
+|       AMC+        |    ✔️    |  ❌  | -                                |
+|     Apple TV      |    ✔️    |  ❌  | -                                |
+|       Crave       |    ✔️    |  ✔️  | -                                |
+|    Crunchyroll    |    ❌    |  ✔️  | -                                |
+|    discovery+     |    ✔️    |  ✔️  | -                                |
+|      Disney+      |    ✔️    |  ❌  | -                                |
+|        Go3        |    ✔️    |  ❌  | -                                |
+|     GoPlay BE     |    ✔️    |  ❌  | -                                |
+|      HBO Go       |    ✔️    |  ❌  | -                                |
+|      HBO Max      |    ✔️    |  ✔️  | -                                |
+|      Hotstar      |    ✔️    |  ❌  | -                                |
+|      Kijk.nl      |    ✔️    |  ❌  | -                                |
+|       MUBI        |    ✔️    |  ✔️  | -                                |
+|      Netflix      |    ✔️    |  ✔️  | -                                |
+|        NRK        |    ✔️    |  ✔️  | -                                |
+|     Player.pl     |    ✔️    |  ❌  | -                                |
+|  Polsatboxgo.pl   |    ✔️    |  ❌  | -                                |
+|    SkyShowtime    |    ✔️    |  ❌  | -                                |
+|       Star+       |    ✔️    |  ❌  | -                                |
+|    Streamz BE     |    ✔️    |  ❌  | -                                |
+|      Stremio      |    ✔️    |  ❌  | -                                |
+|      Tet TV+      |    ✔️    |  ❌  | -                                |
+|     TV 2 PLAY     |    ✔️    |  ✔️  | -                                |
+|      Viaplay      |    ✔️    |  ✔️  | -                                |
+|       Vidio       |    ✔️    |  ❌  | -                                |
+|     VRTNu BE      |    ✔️    |  ❌  | -                                |
+|     VTMGo BE      |    ✔️    |  ❌  | -                                |
+|    Wakanim.tv     |    ✔️    |  ❌  | -                                |
 
 <!-- services-end -->
-
-#### Apple TV
-
-Apple TV support is scrobble-only; historical watch synchronization is not available. Enable Apple TV in the extension options and approve the optional `*://*.tv.apple.com/*` permission when prompted.
-
-The scrobbler supports on-demand movies and TV episodes played on `tv.apple.com`, including playback started from title pages, Continue Watching, featured content, and other homepage shelves. It follows in-page navigation and autoplay transitions even when Apple TV keeps the browser URL on the homepage.
-
-Live sports, trailers, extras, previews, promotional background videos, and other non-feature content are intentionally excluded.
 
 ### How does the extension work?
 

--- a/src/services/apple-tv/AppleTvApi.ts
+++ b/src/services/apple-tv/AppleTvApi.ts
@@ -1,0 +1,10 @@
+import { AppleTvService } from '@/apple-tv/AppleTvService';
+import { ServiceApi } from '@apis/ServiceApi';
+
+class _AppleTvApi extends ServiceApi {
+	constructor() {
+		super(AppleTvService.id);
+	}
+}
+
+export const AppleTvApi = new _AppleTvApi();

--- a/src/services/apple-tv/AppleTvParser.ts
+++ b/src/services/apple-tv/AppleTvParser.ts
@@ -42,10 +42,11 @@ interface AppleTvEpisodeDetails {
 /**
  * Apple TV renders promotional videos throughout the site, while the actual long-form
  * player is mounted in a dedicated `video-container`. Item metadata is server-rendered
- * as semantic meta tags and JSON-LD, while series-page playback exposes the current
- * episode through player metadata and the episode shelf. Page metadata is checked
- * against the current `umc.cmc.*` URL ID, and player metadata is fingerprinted so an
- * autoplay transition cannot retain the previous episode.
+ * as semantic meta tags and JSON-LD, while active player overlays expose the current
+ * item through player metadata. Homepage playback can leave the URL at its locale root,
+ * so matching content links provide exact IDs when available. Page metadata is checked
+ * against the current `umc.cmc.*` URL ID, and player metadata is fingerprinted so SPA
+ * and autoplay transitions cannot retain the previous item.
  */
 class _AppleTvParser extends ScrobbleParser {
 	private itemIdentity: string | null = null;

--- a/src/services/apple-tv/AppleTvParser.ts
+++ b/src/services/apple-tv/AppleTvParser.ts
@@ -39,6 +39,16 @@ interface AppleTvEpisodeDetails {
 	title: string;
 }
 
+interface AppleTvPlayerMetadata {
+	subtitle: string;
+	title: string;
+}
+
+interface AppleTvPlaybackIdentityCache {
+	identity: string;
+	key: string;
+}
+
 /**
  * Apple TV renders promotional videos throughout the site, while the actual long-form
  * player is mounted in a dedicated `video-container`. Item metadata is server-rendered
@@ -51,6 +61,7 @@ interface AppleTvEpisodeDetails {
 class _AppleTvParser extends ScrobbleParser {
 	private completionPending = false;
 	private itemIdentity: string | null = null;
+	private playbackIdentityCache: AppleTvPlaybackIdentityCache | null = null;
 
 	constructor() {
 		super(AppleTvApi, {
@@ -87,6 +98,7 @@ class _AppleTvParser extends ScrobbleParser {
 		super.clearItem();
 		this.completionPending = false;
 		this.itemIdentity = null;
+		this.playbackIdentityCache = null;
 	}
 
 	protected parseItemFromApi(): Promise<ScrobbleItem | null> {
@@ -193,13 +205,7 @@ class _AppleTvParser extends ScrobbleParser {
 	}
 
 	private parseItemFromPlayer(route: AppleTvRoute | null): ScrobbleItem | null {
-		const player = document.querySelector('[data-testid="video-player"]');
-		const title = player
-			?.querySelector('[data-testid="player-metadata-title"]')
-			?.textContent?.trim();
-		const subtitle = player
-			?.querySelector('[data-testid="player-metadata-subtitle"]')
-			?.textContent?.trim();
+		const { title, subtitle } = this.getPlayerMetadata();
 		if (!title) {
 			return null;
 		}
@@ -219,7 +225,7 @@ class _AppleTvParser extends ScrobbleParser {
 			return null;
 		}
 
-		const details = this.parsePlayerEpisode(title, subtitle ?? '');
+		const details = this.parsePlayerEpisode(title, subtitle);
 		if (details) {
 			const showId =
 				route?.type === 'show' ? route.id : (this.findContentId('show', details.showTitle) ?? null);
@@ -266,33 +272,48 @@ class _AppleTvParser extends ScrobbleParser {
 	}
 
 	private getPlaybackIdentity(route: AppleTvRoute | null): string | null {
-		const player = document.querySelector('[data-testid="video-player"]');
-		const title = player
-			?.querySelector('[data-testid="player-metadata-title"]')
-			?.textContent?.trim();
-		const subtitle = player
-			?.querySelector('[data-testid="player-metadata-subtitle"]')
-			?.textContent?.trim();
-		const details = title ? this.parsePlayerEpisode(title, subtitle ?? '') : null;
+		const { title, subtitle } = this.getPlayerMetadata();
+		const key = JSON.stringify([route?.type ?? '', route?.id ?? '', title, subtitle]);
+		if (this.playbackIdentityCache?.key === key) {
+			return this.playbackIdentityCache.identity;
+		}
+
+		const details = title ? this.parsePlayerEpisode(title, subtitle) : null;
+		let identity: string | null;
 		if (details) {
 			const showId =
 				route?.type === 'show' ? route.id : this.findContentId('show', details.showTitle);
-			return this.getEpisodeIdentity(showId ?? route?.id ?? 'player', details);
-		}
-		if (!title) {
+			identity = this.getEpisodeIdentity(showId ?? route?.id ?? 'player', details);
+		} else if (!title) {
 			// Player controls can hide without ending playback. Retain the last confirmed
 			// identity until either new metadata appears or the video itself disappears.
 			if (this.itemIdentity) {
-				return this.itemIdentity;
+				identity = this.itemIdentity;
+			} else if (route?.type === 'episode') {
+				identity = `episode:${route.id}`;
+			} else {
+				identity = route?.type === 'movie' ? `movie:${route.id}` : null;
 			}
-			if (route?.type === 'episode') {
-				return `episode:${route.id}`;
-			}
-			return route?.type === 'movie' ? `movie:${route.id}` : null;
+		} else {
+			const movieId = route?.type === 'movie' ? route.id : this.findContentId('movie', title);
+			identity = movieId ? `movie:${movieId}` : null;
 		}
 
-		const movieId = route?.type === 'movie' ? route.id : this.findContentId('movie', title);
-		return movieId ? `movie:${movieId}` : null;
+		// Do not cache misses: homepage shelves can load after player metadata, and a
+		// later tick must be able to resolve the same title against the updated DOM.
+		this.playbackIdentityCache = identity ? { identity, key } : null;
+		return identity;
+	}
+
+	private getPlayerMetadata(): AppleTvPlayerMetadata {
+		const player = document.querySelector('[data-testid="video-player"]');
+		return {
+			title:
+				player?.querySelector('[data-testid="player-metadata-title"]')?.textContent?.trim() ?? '',
+			subtitle:
+				player?.querySelector('[data-testid="player-metadata-subtitle"]')?.textContent?.trim() ??
+				'',
+		};
 	}
 
 	private getEpisodeIdentity(routeId: string, details: AppleTvEpisodeDetails): string {
@@ -372,9 +393,7 @@ class _AppleTvParser extends ScrobbleParser {
 	private playerMatchesPageTitle(route: AppleTvRoute): boolean {
 		const ld = this.getLdItem<AppleTvLdMovie>('Movie', route.id);
 		const pageTitle = this.getMovieTitle(ld);
-		const playerTitle = document
-			.querySelector('[data-testid="video-player"] [data-testid="player-metadata-title"]')
-			?.textContent?.trim();
+		const { title: playerTitle } = this.getPlayerMetadata();
 		return (
 			!!pageTitle &&
 			!!playerTitle &&

--- a/src/services/apple-tv/AppleTvParser.ts
+++ b/src/services/apple-tv/AppleTvParser.ts
@@ -103,7 +103,7 @@ class _AppleTvParser extends ScrobbleParser {
 		}
 
 		const metadataId = this.getMetaContent('apple:content_id');
-		if (route.type === 'movie' && metadataId === route.id && !this.playerMatchesPageTitle()) {
+		if (route.type === 'movie' && metadataId === route.id && !this.playerMatchesPageTitle(route)) {
 			return null;
 		}
 		if (metadataId !== route.id) {
@@ -135,7 +135,7 @@ class _AppleTvParser extends ScrobbleParser {
 
 	private parseMovie(route: AppleTvRoute): MovieItem | null {
 		const ld = this.getLdItem<AppleTvLdMovie>('Movie', route.id);
-		const title = this.getMetaContent('apple:title') || ld?.name?.trim() || '';
+		const title = this.getMovieTitle(ld);
 		if (!title) {
 			return null;
 		}
@@ -145,7 +145,7 @@ class _AppleTvParser extends ScrobbleParser {
 			ld?.datePublished ||
 			ld?.dateCreated ||
 			'';
-		const year = parseInt(/^(?<year>\d{4})/.exec(releaseDate)?.groups?.year ?? '') || 0;
+		const year = parseInt(/^(?<year>\d{4})/.exec(releaseDate)?.groups?.year ?? '', 10) || 0;
 
 		return new MovieItem({
 			serviceId: this.api.id,
@@ -364,13 +364,14 @@ class _AppleTvParser extends ScrobbleParser {
 
 	private normalizeTitle(value: string): string {
 		return value
-			.toLocaleLowerCase()
+			.toLowerCase()
 			.replace(/[^\p{L}\p{N}]+/gu, ' ')
 			.trim();
 	}
 
-	private playerMatchesPageTitle(): boolean {
-		const pageTitle = this.getMetaContent('apple:title');
+	private playerMatchesPageTitle(route: AppleTvRoute): boolean {
+		const ld = this.getLdItem<AppleTvLdMovie>('Movie', route.id);
+		const pageTitle = this.getMovieTitle(ld);
 		const playerTitle = document
 			.querySelector('[data-testid="video-player"] [data-testid="player-metadata-title"]')
 			?.textContent?.trim();
@@ -378,6 +379,14 @@ class _AppleTvParser extends ScrobbleParser {
 			!!pageTitle &&
 			!!playerTitle &&
 			this.normalizeTitle(pageTitle) === this.normalizeTitle(playerTitle)
+		);
+	}
+
+	private getMovieTitle(ld: AppleTvLdMovie | null): string {
+		return (
+			this.getMetaContent('apple:title') ||
+			ld?.name?.trim() ||
+			this.getMetaContent('og:title', 'property')
 		);
 	}
 
@@ -483,7 +492,7 @@ class _AppleTvParser extends ScrobbleParser {
 	}
 
 	private parseNonNegativeInteger(value: number | string | undefined): number | null {
-		const parsed = typeof value === 'number' ? value : parseInt(value ?? '');
+		const parsed = typeof value === 'number' ? value : parseInt(value ?? '', 10);
 		return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
 	}
 }

--- a/src/services/apple-tv/AppleTvParser.ts
+++ b/src/services/apple-tv/AppleTvParser.ts
@@ -1,0 +1,466 @@
+import { AppleTvApi } from '@/apple-tv/AppleTvApi';
+import { ScrobbleParser, ScrobblePlayback } from '@common/ScrobbleParser';
+import { EpisodeItem, MovieItem, ScrobbleItem } from '@models/Item';
+
+type AppleTvContentType = 'episode' | 'movie' | 'show';
+type AppleTvLdType = 'Episode' | 'Movie';
+
+interface AppleTvRoute {
+	id: string;
+	type: AppleTvContentType;
+}
+
+interface AppleTvLdBase {
+	'@graph'?: AppleTvLdItem[];
+	'@type'?: string | string[];
+	dateCreated?: string;
+	datePublished?: string;
+	name?: string;
+	url?: string;
+}
+
+interface AppleTvLdMovie extends AppleTvLdBase {
+	'@type'?: 'Movie' | string[];
+}
+
+interface AppleTvLdEpisode extends AppleTvLdBase {
+	'@type'?: 'Episode' | string[];
+	episodeNumber?: number | string;
+	partOfSeason?: number | string | { seasonNumber?: number | string };
+	partOfSeries?: { name?: string };
+}
+
+type AppleTvLdItem = AppleTvLdMovie | AppleTvLdEpisode;
+
+interface AppleTvEpisodeDetails {
+	number: number;
+	season: number;
+	showTitle: string;
+	title: string;
+}
+
+/**
+ * Apple TV renders promotional videos throughout the site, while the actual long-form
+ * player is mounted in a dedicated `video-container`. Item metadata is server-rendered
+ * as semantic meta tags and JSON-LD, while series-page playback exposes the current
+ * episode through player metadata and the episode shelf. Page metadata is checked
+ * against the current `umc.cmc.*` URL ID, and player metadata is fingerprinted so an
+ * autoplay transition cannot retain the previous episode.
+ */
+class _AppleTvParser extends ScrobbleParser {
+	private itemIdentity: string | null = null;
+
+	constructor() {
+		super(AppleTvApi, {
+			videoPlayerSelector: '[data-testid="video-container"] video',
+			watchingUrlRegex: /\/(?<contentType>movie|episode|show)\/[^/?#]+\/(?<id>umc\.cmc\.[^/?#]+)/,
+		});
+	}
+
+	async parsePlayback(): Promise<ScrobblePlayback | null> {
+		const route = this.parseRoute();
+		const identity = this.getPlaybackIdentity(route);
+		if (this.getItem() && this.itemIdentity !== identity) {
+			this.clearItem();
+			this.itemIdentity = null;
+		}
+
+		const playback = await super.parsePlayback();
+		if (playback && this.getItem()) {
+			this.itemIdentity = identity;
+		}
+		return playback;
+	}
+
+	protected parseItemFromApi(): Promise<ScrobbleItem | null> {
+		return Promise.resolve(null);
+	}
+
+	protected parseItemFromDom(): ScrobbleItem | null {
+		const route = this.parseRoute();
+		if (!document.querySelector('[data-testid="video-player"]') || this.isExcludedLocation()) {
+			return null;
+		}
+		if (!route) {
+			return this.parseItemFromPlayer(null);
+		}
+
+		const metadataId = this.getMetaContent('apple:content_id');
+		if (route.type === 'movie' && metadataId === route.id && !this.playerMatchesPageTitle()) {
+			return null;
+		}
+		if (metadataId !== route.id) {
+			return this.parseItemFromPlayer(route);
+		}
+
+		const item =
+			route.type === 'movie'
+				? this.parseMovie(route)
+				: route.type === 'episode'
+					? this.parseEpisode(route)
+					: null;
+		return item ?? this.parseItemFromPlayer(route);
+	}
+
+	private parseRoute(): AppleTvRoute | null {
+		const match = /\/(?<contentType>movie|episode|show)\/[^/?#]+\/(?<id>umc\.cmc\.[^/?#]+)/.exec(
+			this.getLocation()
+		);
+		if (!match?.groups) {
+			return null;
+		}
+
+		return {
+			id: match.groups.id,
+			type: match.groups.contentType as AppleTvContentType,
+		};
+	}
+
+	private parseMovie(route: AppleTvRoute): MovieItem | null {
+		const ld = this.getLdItem<AppleTvLdMovie>('Movie', route.id);
+		const title = this.getMetaContent('apple:title') || ld?.name?.trim() || '';
+		if (!title) {
+			return null;
+		}
+
+		const releaseDate =
+			this.getMetaContent('og:video:release_date', 'property') ||
+			ld?.datePublished ||
+			ld?.dateCreated ||
+			'';
+		const year = parseInt(/^(?<year>\d{4})/.exec(releaseDate)?.groups?.year ?? '') || 0;
+
+		return new MovieItem({
+			serviceId: this.api.id,
+			id: route.id,
+			title,
+			year,
+		});
+	}
+
+	private parseEpisode(route: AppleTvRoute): EpisodeItem | null {
+		const ld = this.getLdItem<AppleTvLdEpisode>('Episode', route.id);
+		const details = this.getEpisodeDetails(ld);
+		if (!details) {
+			return null;
+		}
+
+		return this.buildEpisode(route.id, details);
+	}
+
+	private getEpisodeDetails(ld: AppleTvLdEpisode | null): AppleTvEpisodeDetails | null {
+		if (!ld) {
+			return null;
+		}
+
+		const seasonValue =
+			typeof ld.partOfSeason === 'object' ? ld.partOfSeason.seasonNumber : ld.partOfSeason;
+		const season = this.parseNonNegativeInteger(seasonValue);
+		const number = this.parseNonNegativeInteger(ld.episodeNumber);
+		const title =
+			this.getMetaContent('apple:title') ||
+			document.querySelector('.page-header .episode-title')?.textContent?.trim() ||
+			'';
+		const showTitle =
+			ld.partOfSeries?.name?.trim() ||
+			document
+				.querySelector<HTMLAnchorElement>('.page-header a[href*="/show/"]')
+				?.textContent?.trim() ||
+			this.getShowTitleFromLdName(ld.name, title);
+
+		if (season === null || number === null || !title || !showTitle) {
+			return null;
+		}
+
+		return { season, number, title, showTitle };
+	}
+
+	private parseItemFromPlayer(route: AppleTvRoute | null): ScrobbleItem | null {
+		const player = document.querySelector('[data-testid="video-player"]');
+		const title = player
+			?.querySelector('[data-testid="player-metadata-title"]')
+			?.textContent?.trim();
+		const subtitle = player
+			?.querySelector('[data-testid="player-metadata-subtitle"]')
+			?.textContent?.trim();
+		if (!title) {
+			return null;
+		}
+
+		if (route?.type === 'movie') {
+			const movieId =
+				this.getMetaContent('apple:content_id') === route.id
+					? route.id
+					: this.findContentId('movie', title);
+			return movieId ? new MovieItem({ serviceId: this.api.id, id: movieId, title }) : null;
+		}
+		if (
+			route?.type === 'show' &&
+			(this.getMetaContent('apple:content_id') !== route.id ||
+				this.getMetaContent('apple:title') !== title)
+		) {
+			return null;
+		}
+
+		const details = this.parsePlayerEpisode(title, subtitle ?? '');
+		if (details) {
+			const showId =
+				route?.type === 'show' ? route.id : (this.findContentId('show', details.showTitle) ?? null);
+			const id =
+				route?.type === 'episode'
+					? route.id
+					: (this.findEpisodeId(details, showId) ??
+						this.getEpisodeIdentity(showId ?? 'player', details));
+			return this.buildEpisode(id, details);
+		}
+
+		if (route) {
+			return null;
+		}
+
+		const movieId = this.findContentId('movie', title);
+		return movieId ? new MovieItem({ serviceId: this.api.id, id: movieId, title }) : null;
+	}
+
+	private parsePlayerEpisode(showTitle: string, subtitle: string): AppleTvEpisodeDetails | null {
+		const titleMatch = this.matchSeasonAndEpisode(showTitle);
+		const subtitleMatch = this.matchSeasonAndEpisode(subtitle);
+		const match = subtitleMatch ?? titleMatch;
+		if (!match?.groups) {
+			return null;
+		}
+
+		const season = this.parseNonNegativeInteger(match.groups.season);
+		const number = this.parseNonNegativeInteger(match.groups.number);
+		if (season === null || number === null) {
+			return null;
+		}
+
+		const episodeTitle = subtitleMatch
+			? this.removeSeasonAndEpisode(subtitle, subtitleMatch)
+			: this.removeSeasonAndEpisode(showTitle, titleMatch);
+		const parsedShowTitle = subtitleMatch ? showTitle : subtitle;
+
+		if (!episodeTitle || !parsedShowTitle) {
+			return null;
+		}
+
+		return { season, number, title: episodeTitle, showTitle: parsedShowTitle };
+	}
+
+	private getPlaybackIdentity(route: AppleTvRoute | null): string | null {
+		const player = document.querySelector('[data-testid="video-player"]');
+		const title = player
+			?.querySelector('[data-testid="player-metadata-title"]')
+			?.textContent?.trim();
+		const subtitle = player
+			?.querySelector('[data-testid="player-metadata-subtitle"]')
+			?.textContent?.trim();
+		const details = title ? this.parsePlayerEpisode(title, subtitle ?? '') : null;
+		if (details) {
+			const showId =
+				route?.type === 'show' ? route.id : this.findContentId('show', details.showTitle);
+			return this.getEpisodeIdentity(showId ?? route?.id ?? 'player', details);
+		}
+		if (!title) {
+			return null;
+		}
+
+		const movieId = route?.type === 'movie' ? route.id : this.findContentId('movie', title);
+		return movieId ? `movie:${movieId}` : null;
+	}
+
+	private getEpisodeIdentity(routeId: string, details: AppleTvEpisodeDetails): string {
+		return `${routeId}:s${details.season}e${details.number}:${details.showTitle}:${details.title}`;
+	}
+
+	private findEpisodeId(details: AppleTvEpisodeDetails, showId: string | null): string | null {
+		const ids = Array.from(
+			document.querySelectorAll<HTMLAnchorElement>('a[href*="/episode/"]')
+		).flatMap((anchor) => {
+			const text = anchor.textContent?.trim() ?? '';
+			const titleMatches = this.getAnchorTitles(anchor).some(
+				(value) => this.normalizeTitle(value) === this.normalizeTitle(details.title)
+			);
+			const textMatches = this.normalizeTitle(text).includes(this.normalizeTitle(details.title));
+			const numbering = this.matchSeasonAndEpisode(text);
+			if (
+				(!titleMatches && !textMatches) ||
+				(numbering?.groups &&
+					(numbering.groups.season !== details.season.toString() ||
+						numbering.groups.number !== details.number.toString()))
+			) {
+				return [];
+			}
+
+			try {
+				const url = new URL(anchor.href, window.location.origin);
+				const linkedShowId = url.searchParams.get('showId');
+				const id =
+					!showId || !linkedShowId || linkedShowId === showId
+						? this.getContentIdFromUrl(url.href, 'episode')
+						: null;
+				return id ? [id] : [];
+			} catch (_err) {
+				return [];
+			}
+		});
+
+		return ids.length === 1 ? ids[0] : null;
+	}
+
+	private findContentId(type: 'movie' | 'show', title: string): string | null {
+		const normalizedTitle = this.normalizeTitle(title);
+		const ids = Array.from(
+			document.querySelectorAll<HTMLAnchorElement>(`a[href*="/${type}/"]`)
+		).flatMap((anchor) => {
+			const matches = this.getAnchorTitles(anchor).some(
+				(value) => this.normalizeTitle(value) === normalizedTitle
+			);
+			const id = matches ? this.getContentIdFromUrl(anchor.href, type) : null;
+			return id ? [id] : [];
+		});
+
+		const uniqueIds = Array.from(new Set(ids));
+		return uniqueIds.length === 1 ? uniqueIds[0] : null;
+	}
+
+	private getAnchorTitles(anchor: HTMLAnchorElement): string[] {
+		return [
+			anchor.getAttribute('aria-label') ?? '',
+			anchor.getAttribute('title') ?? '',
+			...Array.from(anchor.querySelectorAll<HTMLImageElement>('img[alt]')).map(
+				(image) => image.alt
+			),
+			anchor.querySelector('.title')?.textContent?.trim() ?? '',
+			anchor.textContent?.trim() ?? '',
+		].filter(Boolean);
+	}
+
+	private normalizeTitle(value: string): string {
+		return value
+			.toLocaleLowerCase()
+			.replace(/[^\p{L}\p{N}]+/gu, ' ')
+			.trim();
+	}
+
+	private playerMatchesPageTitle(): boolean {
+		const pageTitle = this.getMetaContent('apple:title');
+		const playerTitle = document
+			.querySelector('[data-testid="video-player"] [data-testid="player-metadata-title"]')
+			?.textContent?.trim();
+		return (
+			!!pageTitle &&
+			!!playerTitle &&
+			this.normalizeTitle(pageTitle) === this.normalizeTitle(playerTitle)
+		);
+	}
+
+	private getContentIdFromUrl(url: string, type: AppleTvContentType): string | null {
+		try {
+			return (
+				new RegExp(`/${type}/[^/?#]+/(?<id>umc\\.cmc\\.[^/?#]+)`).exec(
+					new URL(url, window.location.origin).pathname
+				)?.groups?.id ?? null
+			);
+		} catch (_err) {
+			return null;
+		}
+	}
+
+	private isExcludedLocation(): boolean {
+		return /\/(?:clip|sporting-event)\//.test(new URL(this.getLocation()).pathname);
+	}
+
+	private matchSeasonAndEpisode(value: string): RegExpExecArray | null {
+		return /\bS(?<season>\d+)\s*[,·]?\s*E(?<number>\d+)\b/i.exec(value);
+	}
+
+	private removeSeasonAndEpisode(value: string, match: RegExpExecArray | null): string {
+		if (!match) {
+			return value.trim();
+		}
+		return value
+			.replace(match[0], '')
+			.replace(/^[\s,·:–—-]+|[\s,·:–—-]+$/g, '')
+			.trim();
+	}
+
+	private buildEpisode(id: string, details: AppleTvEpisodeDetails): EpisodeItem {
+		return new EpisodeItem({
+			serviceId: this.api.id,
+			id,
+			title: details.title,
+			season: details.season,
+			number: details.number,
+			show: {
+				serviceId: this.api.id,
+				title: details.showTitle,
+			},
+		});
+	}
+
+	private getLdItem<T extends AppleTvLdItem>(type: AppleTvLdType, id: string): T | null {
+		for (const script of Array.from(
+			document.querySelectorAll<HTMLScriptElement>('script[type="application/ld+json"]')
+		)) {
+			let parsed: AppleTvLdItem | AppleTvLdItem[];
+			try {
+				parsed = JSON.parse(script.textContent ?? '') as AppleTvLdItem | AppleTvLdItem[];
+			} catch (_err) {
+				continue;
+			}
+
+			const roots = Array.isArray(parsed) ? parsed : [parsed];
+			const items = roots.flatMap((root) => [root, ...(root['@graph'] ?? [])]);
+			for (const item of items) {
+				const types = Array.isArray(item['@type']) ? item['@type'] : [item['@type']];
+				if (!types.includes(type)) {
+					continue;
+				}
+
+				const isCurrentItem = item.url
+					? this.urlContainsExactId(item.url, id)
+					: this.getMetaContent('apple:content_id') === id;
+				if (isCurrentItem) {
+					return item as T;
+				}
+			}
+		}
+		return null;
+	}
+
+	private urlContainsExactId(url: string | undefined, id: string): boolean {
+		if (!url) {
+			return false;
+		}
+
+		try {
+			return new URL(url, window.location.origin).pathname.split('/').includes(id);
+		} catch (_err) {
+			return false;
+		}
+	}
+
+	private getShowTitleFromLdName(name: string | undefined, episodeTitle: string): string {
+		if (!name || !episodeTitle) {
+			return '';
+		}
+
+		const suffix = ` - ${episodeTitle}`;
+		return name.endsWith(suffix) ? name.slice(0, -suffix.length).trim() : '';
+	}
+
+	private getMetaContent(name: string, attribute = 'name'): string {
+		return (
+			document.querySelector<HTMLMetaElement>(`meta[${attribute}="${name}"]`)?.content?.trim() ?? ''
+		);
+	}
+
+	private parseNonNegativeInteger(value: number | string | undefined): number | null {
+		const parsed = typeof value === 'number' ? value : parseInt(value ?? '');
+		return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+	}
+}
+
+export const AppleTvParser = new _AppleTvParser();

--- a/src/services/apple-tv/AppleTvParser.ts
+++ b/src/services/apple-tv/AppleTvParser.ts
@@ -49,6 +49,7 @@ interface AppleTvEpisodeDetails {
  * and autoplay transitions cannot retain the previous item.
  */
 class _AppleTvParser extends ScrobbleParser {
+	private completionPending = false;
 	private itemIdentity: string | null = null;
 
 	constructor() {
@@ -59,18 +60,33 @@ class _AppleTvParser extends ScrobbleParser {
 	}
 
 	async parsePlayback(): Promise<ScrobblePlayback | null> {
+		if (this.completionPending && this.getItem()) {
+			// The previous tick persisted the final progress. An empty playback tick now
+			// lets ScrobbleEvents send /stop with that progress before clearing the item.
+			return null;
+		}
+
 		const route = this.parseRoute();
 		const identity = this.getPlaybackIdentity(route);
 		if (this.getItem() && this.itemIdentity !== identity) {
-			this.clearItem();
-			this.itemIdentity = null;
+			// Keep the previous item alive for one empty-playback cycle. ScrobbleEvents will
+			// stop it with its latest progress, then the controller clears it. Clearing here
+			// would make stopScrobble() return before sending Trakt's final /stop request.
+			return null;
 		}
 
 		const playback = await super.parsePlayback();
 		if (playback && this.getItem()) {
 			this.itemIdentity = identity;
+			this.completionPending = !!this.videoPlayer?.ended || playback.progress >= 99.9;
 		}
 		return playback;
+	}
+
+	override clearItem(): void {
+		super.clearItem();
+		this.completionPending = false;
+		this.itemIdentity = null;
 	}
 
 	protected parseItemFromApi(): Promise<ScrobbleItem | null> {
@@ -264,7 +280,15 @@ class _AppleTvParser extends ScrobbleParser {
 			return this.getEpisodeIdentity(showId ?? route?.id ?? 'player', details);
 		}
 		if (!title) {
-			return null;
+			// Player controls can hide without ending playback. Retain the last confirmed
+			// identity until either new metadata appears or the video itself disappears.
+			if (this.itemIdentity) {
+				return this.itemIdentity;
+			}
+			if (route?.type === 'episode') {
+				return `episode:${route.id}`;
+			}
+			return route?.type === 'movie' ? `movie:${route.id}` : null;
 		}
 
 		const movieId = route?.type === 'movie' ? route.id : this.findContentId('movie', title);

--- a/src/services/apple-tv/AppleTvService.ts
+++ b/src/services/apple-tv/AppleTvService.ts
@@ -1,0 +1,12 @@
+import { Service } from '@models/Service';
+
+export const AppleTvService = new Service({
+	id: 'apple-tv',
+	name: 'Apple TV',
+	homePage: 'https://tv.apple.com/',
+	hostPatterns: ['*://*.tv.apple.com/*'],
+	hasScrobbler: true,
+	hasSync: false,
+	hasAutoSync: false,
+	limitations: ['Live sports, trailers, extras, and previews are not scrobbled.'],
+});

--- a/src/services/apple-tv/apple-tv.ts
+++ b/src/services/apple-tv/apple-tv.ts
@@ -1,0 +1,4 @@
+import '@/apple-tv/AppleTvParser';
+import { init } from '@service';
+
+void init('apple-tv');


### PR DESCRIPTION
## Summary

- add Apple TV as a scrobble-only service for `tv.apple.com`
- support on-demand movies and episodes launched from title pages, Continue Watching, featured content, homepage shelves, and autoplay transitions
- exclude live sports, trailers, extras, previews, and promotional/background videos
- list Apple TV in the existing README service table

## Why

Apple TV often mounts the real player as an overlay without changing the homepage URL. Route-only detection therefore misses playback launched from several homepage surfaces and can retain stale metadata during SPA or autoplay transitions.

The parser combines exact content-route and Apple metadata validation with scoped player hooks. When the URL remains on the homepage, it resolves matching Apple content IDs from the page's content links and fingerprints player metadata so item changes invalidate the cache.

## Implementation

- register the `apple-tv` service for `*://*.tv.apple.com/*`, with scrobbling enabled and sync disabled
- track only `[data-testid="video-container"] video`
- parse locale-independent movie, episode, and show routes using exact `umc.cmc.*` IDs
- parse validated Movie and Episode JSON-LD where available
- use player title/subtitle metadata for homepage overlays, show-page playback, SPA navigation, and autoplay
- cross-check movie player titles against page metadata so trailers and extras cannot inherit a parent movie ID
- add Apple TV to the README service table without reformatting it

## Validation

- `pnpm tsc`
- `pnpm biome check src/services/apple-tv README.md`
- `pnpm run build-dev`
- verified `apple-tv.js` in Chrome and Firefox builds
- verified Apple TV optional host permission in both generated manifests
- inspected authenticated live movie and episode playback from featured content, Continue Watching, standard shelves, and button-only homepage cards
