### PR TITLE
fix/autosync hangs

### DIFF
--- a/src/apis/TraktSearch.ts
+++ b/src/apis/TraktSearch.ts
@@ -1,4 +1,5 @@
 import { CorrectionApi } from '@apis/CorrectionApi';
+import { TmdbApi } from '@apis/TmdbApi';
 import { TraktApi } from '@apis/TraktApi';
 import { CacheItems } from '@common/Cache';
 import { RequestError } from '@common/RequestError';
@@ -222,7 +223,6 @@ class _TraktSearch extends TraktApi {
 				// original title and matching the TMDB ID against Trakt results can
 				// resolve cases where Trakt lists a show under a different (e.g. English) name.
 				try {
-					const { TmdbApi } = await import('@apis/TmdbApi');
 					const tmdbShow = await TmdbApi.searchTvShow(item.title, item.year);
 					if (tmdbShow) {
 						const tmdbMatch = searchItems.find((si) => {
@@ -477,7 +477,6 @@ class _TraktSearch extends TraktApi {
 		cancelKey: string
 	): Promise<string | null> {
 		try {
-			const { TmdbApi } = await import('@apis/TmdbApi');
 			const tmdbShow = await TmdbApi.searchTvShow(item.show.title, item.show.year, item.serviceId);
 
 			if (!tmdbShow) {

--- a/src/common/BrowserAction.ts
+++ b/src/common/BrowserAction.ts
@@ -42,8 +42,9 @@ class _BrowserAction {
 		if (Shared.pageType === 'background') {
 			this.currentIcon = browser.runtime.getURL('images/uts-icon-selected-38.png');
 			if (this.rotating) {
-				await this.setStaticIcon();
-				await this.setRotatingIcon();
+				// Only swap the image being rotated - restarting the rotation here would
+				// clear a pending cancellation and could leave the icon spinning forever.
+				await this.updateRotatingIcon();
 			} else {
 				await this.instance.setIcon({
 					path: this.currentIcon,
@@ -58,8 +59,9 @@ class _BrowserAction {
 		if (Shared.pageType === 'background') {
 			this.currentIcon = browser.runtime.getURL('images/uts-icon-38.png');
 			if (this.rotating) {
-				await this.setStaticIcon();
-				await this.setRotatingIcon();
+				// Only swap the image being rotated - restarting the rotation here would
+				// clear a pending cancellation and could leave the icon spinning forever.
+				await this.updateRotatingIcon();
 			} else {
 				await this.instance.setIcon({
 					path: this.currentIcon,
@@ -72,12 +74,7 @@ class _BrowserAction {
 
 	async setRotatingIcon(): Promise<void> {
 		if (Shared.pageType === 'background') {
-			const imageResponse = await Requests.fetch({
-				method: 'GET',
-				url: this.currentIcon,
-			});
-			const imageBlob = await imageResponse.blob();
-			const image = await createImageBitmap(imageBlob);
+			const image = await this.createIconBitmap();
 			const canvas = new OffscreenCanvas(image.width, image.height);
 			const context = canvas.getContext('2d', {
 				willReadFrequently: true,
@@ -89,9 +86,30 @@ class _BrowserAction {
 				degrees: 0,
 				canceled: false,
 			};
-			await this.rotateIcon();
+			await this.rotateIcon(this.rotating);
 		} else {
 			await Messaging.toExtension({ action: 'set-rotating-icon' });
+		}
+	}
+
+	private async createIconBitmap(): Promise<ImageBitmap> {
+		const imageResponse = await Requests.fetch({
+			method: 'GET',
+			url: this.currentIcon,
+		});
+		const imageBlob = await imageResponse.blob();
+		return createImageBitmap(imageBlob);
+	}
+
+	private async updateRotatingIcon(): Promise<void> {
+		const rotating = this.rotating;
+		if (!rotating) {
+			return;
+		}
+		const image = await this.createIconBitmap();
+		// The rotation may have been replaced or stopped while the image was loading
+		if (this.rotating === rotating) {
+			rotating.image = image;
 		}
 	}
 
@@ -105,12 +123,22 @@ class _BrowserAction {
 		}
 	}
 
-	async rotateIcon(): Promise<void> {
-		if (!this.rotating) {
+	async rotateIcon(rotating: BrowserActionRotating): Promise<void> {
+		if (this.rotating !== rotating) {
+			// A newer rotation has taken over, so let it drive the icon instead
 			return;
 		}
 
-		const { image, canvas, context, degrees } = this.rotating;
+		if (rotating.canceled) {
+			// Restore the static icon - otherwise it would remain stuck on the last rotated frame
+			this.rotating = null;
+			await this.instance.setIcon({
+				path: this.currentIcon,
+			});
+			return;
+		}
+
+		const { image, canvas, context, degrees } = rotating;
 		if (!image || !canvas || !context) {
 			return;
 		}
@@ -131,17 +159,9 @@ class _BrowserAction {
 			) as WebExtAction.ImageDataType,
 		});
 
-		this.rotating.degrees += 15;
-		if (this.rotating.degrees >= 360) {
-			if (this.rotating.canceled) {
-				this.rotating = null;
-				return;
-			}
+		rotating.degrees = (rotating.degrees + 15) % 360;
 
-			this.rotating.degrees = 0;
-		}
-
-		setTimeout(() => void this.rotateIcon(), 30);
+		setTimeout(() => void this.rotateIcon(rotating), 30);
 	}
 }
 

--- a/src/common/BrowserAction.ts
+++ b/src/common/BrowserAction.ts
@@ -106,9 +106,11 @@ class _BrowserAction {
 		if (!rotating) {
 			return;
 		}
+		const icon = this.currentIcon;
 		const image = await this.createIconBitmap();
-		// The rotation may have been replaced or stopped while the image was loading
-		if (this.rotating === rotating) {
+		// The rotation may have been replaced or stopped, or the icon may have changed again,
+		// while the image was loading - in that case the loaded bitmap is stale
+		if (this.rotating === rotating && this.currentIcon === icon) {
 			rotating.image = image;
 		}
 	}

--- a/src/common/ScriptInjector.ts
+++ b/src/common/ScriptInjector.ts
@@ -255,24 +255,29 @@ class _ScriptInjector {
 					return;
 				}
 
-				clearTimeout(timeoutId);
-
-				let value;
-				if (Shared.manifestVersion === 3) {
-					const results = await browser.scripting.executeScript({
-						target: { tabId },
-						func: Shared.functionsToInject[id],
-						args: [params],
-						// @ts-expect-error This is a newer value, so it's missing from the types.
-						world: 'MAIN',
-					});
-					value = results[0].result as T | null;
-				} else {
-					value = (await Messaging.toContent(
-						{ action: 'inject-function', serviceId, key, url, params },
-						tabId
-					)) as T | null;
+				// Keep the timeout active until the injection has settled, so that a hanging
+				// injection cannot leave the promise pending forever. Failures resolve with null.
+				let value: T | null = null;
+				try {
+					if (Shared.manifestVersion === 3) {
+						const results = await browser.scripting.executeScript({
+							target: { tabId },
+							func: Shared.functionsToInject[id],
+							args: [params],
+							// @ts-expect-error This is a newer value, so it's missing from the types.
+							world: 'MAIN',
+						});
+						value = results[0].result as T | null;
+					} else {
+						value = (await Messaging.toContent(
+							{ action: 'inject-function', serviceId, key, url, params },
+							tabId
+						)) as T | null;
+					}
+				} catch (err) {
+					console.log(`[UTS] ScriptInjector.injectInTab: ${id}: injection failed`, err);
 				}
+				clearTimeout(timeoutId);
 				void browser.tabs.remove(tabId);
 				resolve(value);
 

--- a/src/common/ScriptInjector.ts
+++ b/src/common/ScriptInjector.ts
@@ -236,10 +236,26 @@ class _ScriptInjector {
 				return;
 			}
 
+			// If the content script never connects (for example, if the user is logged out and the
+			// page redirects to a domain where it isn't injected), the promise would never settle
+			// and callers (like the auto sync) would hang forever, so give up after a while.
+			const timeoutId = setTimeout(() => {
+				console.log(
+					`[UTS] ScriptInjector.injectInTab: ${id}: timed out waiting for the content script`
+				);
+				Shared.events.unsubscribe('CONTENT_SCRIPT_CONNECT', null, onScriptConnect);
+				if (tabId !== null) {
+					void browser.tabs.remove(tabId);
+				}
+				resolve(null);
+			}, 60e3);
+
 			const onScriptConnect = async (data: ContentScriptConnectData) => {
 				if (typeof tabId === 'undefined' || tabId !== data.tabId) {
 					return;
 				}
+
+				clearTimeout(timeoutId);
 
 				let value;
 				if (Shared.manifestVersion === 3) {
@@ -266,9 +282,21 @@ class _ScriptInjector {
 			Shared.events.subscribe('CONTENT_SCRIPT_CONNECT', null, onScriptConnect);
 
 			Tabs.open(url, { active: false })
-				.then((tab) => (tabId = tab?.id ?? null))
-				.catch(() => {
-					// Do nothing
+				.then((tab) => {
+					tabId = tab?.id ?? null;
+					if (tabId === null) {
+						// Without a tab there is nothing to wait for, so give up instead of hanging
+						console.log(`[UTS] ScriptInjector.injectInTab: ${id}: could not open a tab`);
+						clearTimeout(timeoutId);
+						Shared.events.unsubscribe('CONTENT_SCRIPT_CONNECT', null, onScriptConnect);
+						resolve(null);
+					}
+				})
+				.catch((err) => {
+					console.log(`[UTS] ScriptInjector.injectInTab: ${id}: failed to open tab`, err);
+					clearTimeout(timeoutId);
+					Shared.events.unsubscribe('CONTENT_SCRIPT_CONNECT', null, onScriptConnect);
+					resolve(null);
 				});
 		});
 	}

--- a/src/common/Tabs.ts
+++ b/src/common/Tabs.ts
@@ -24,17 +24,19 @@ class _Tabs {
 				extraProperties,
 			});
 		}
+		// There isn't always an active tab in a normal window (for example, when the background
+		// service worker runs while no browser window is focused), so only use it to position
+		// the new tab and to inherit the cookie store - never fail to open the tab because of it.
 		const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-		if (tabs.length === 0) {
-			return null;
-		}
 		const tabProperties: TabProperties = {
-			index: tabs[0].index + 1,
 			url,
 			...extraProperties,
 		};
-		if (Shared.storage.options.grantCookies && browser.cookies) {
-			tabProperties.cookieStoreId = tabs[0].cookieStoreId;
+		if (tabs.length > 0) {
+			tabProperties.index = tabs[0].index + 1;
+			if (Shared.storage.options.grantCookies && browser.cookies) {
+				tabProperties.cookieStoreId = tabs[0].cookieStoreId;
+			}
 		}
 		return browser.tabs.create(tabProperties);
 	}

--- a/src/common/Tabs.ts
+++ b/src/common/Tabs.ts
@@ -33,9 +33,9 @@ class _Tabs {
 			...extraProperties,
 		};
 		if (tabs.length > 0) {
-			tabProperties.index = tabs[0].index + 1;
+			tabProperties.index ??= tabs[0].index + 1;
 			if (Shared.storage.options.grantCookies && browser.cookies) {
-				tabProperties.cookieStoreId = tabs[0].cookieStoreId;
+				tabProperties.cookieStoreId ??= tabs[0].cookieStoreId;
 			}
 		}
 		return browser.tabs.create(tabProperties);

--- a/src/services/tv2-play/Tv2PlayApi.ts
+++ b/src/services/tv2-play/Tv2PlayApi.ts
@@ -153,7 +153,9 @@ class _Tv2PlayApi extends ServiceApi {
 	}
 
 	isNewHistoryItem(historyItem: Tv2PlayHistoryItem, lastSync: number, _lastSyncId: string) {
-		return new Date(historyItem.date).getTime() > lastSync;
+		// `lastSync` is a unix timestamp in seconds, so the item date must be converted to
+		// seconds as well - comparing milliseconds to seconds would treat every item as new.
+		return Utils.unix(historyItem.date) > lastSync;
 	}
 
 	getHistoryItemId(historyItem: Tv2PlayHistoryItem) {


### PR DESCRIPTION
Various fixes related to looping icon and failing syncs.

- **fix: use static TmdbApi import to avoid hanging chunk load in service worker**
- **fix: compare TV 2 Play history dates in seconds when checking for new items**
- **fix: make background tab script injection fail gracefully instead of hanging**
- **fix: prevent the rotating icon from getting stuck or left tilted**
