### PR TITLE
fix/norwegian services

### DIFF
--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -141,6 +141,7 @@ class _NrkApi extends ServiceApi {
 	PROGRAM_URL: string;
 	token: string;
 	isActivated: boolean;
+	private tokenExpiresAt = 0;
 
 	authRequests = Requests;
 
@@ -161,8 +162,9 @@ class _NrkApi extends ServiceApi {
 			method: 'GET',
 		});
 		const data = JSON.parse(authData) as NrkAuth;
-		const { accessToken, user } = data.session;
+		const { accessToken, expiresIn, user } = data.session;
 		this.token = accessToken.split('"').join('');
+		this.tokenExpiresAt = expiresIn > 0 ? Utils.unix() + expiresIn : 0;
 		this.session = {
 			profileName: user.name,
 		};
@@ -183,7 +185,8 @@ class _NrkApi extends ServiceApi {
 	async loadHistoryItems(cancelKey = 'default'): Promise<NrkProgressItem[]> {
 		// `reset()` clears `nextHistoryUrl` without clearing `isActivated`, so re-activate
 		// whenever the URL is missing to avoid sending a request with an empty URL.
-		if (!this.isActivated || !this.nextHistoryUrl) {
+		// Also re-activate when the access token has expired, to pick up a fresh one.
+		if (!this.isActivated || !this.nextHistoryUrl || this.isTokenExpired()) {
 			await this.activate();
 		}
 		const responseText = await this.authRequests.send({
@@ -199,6 +202,10 @@ class _NrkApi extends ServiceApi {
 			this.hasReachedHistoryEnd = true;
 		}
 		return responseItems;
+	}
+
+	private isTokenExpired(): boolean {
+		return this.tokenExpiresAt > 0 && Utils.unix() >= this.tokenExpiresAt;
 	}
 
 	isNewHistoryItem(historyItem: NrkProgressItem, lastSync: number) {

--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -216,9 +216,14 @@ class _NrkApi extends ServiceApi {
 		return historyItem.id;
 	}
 
-	convertHistoryItems(historyItems: NrkProgressItem[]) {
-		const promises = historyItems.map((historyItem) => this.parseHistoryItem(historyItem));
-		return Promise.all(promises);
+	async convertHistoryItems(historyItems: NrkProgressItem[]) {
+		const items: ScrobbleItem[] = [];
+		// Each item requires a program page lookup - run them sequentially to avoid
+		// bursting the API with one request per item on large (first-time) syncs
+		for (const historyItem of historyItems) {
+			items.push(await this.parseHistoryItem(historyItem));
+		}
+		return items;
 	}
 
 	updateItemFromHistory(item: ScrobbleItemValues, historyItem: NrkProgressItem): Promisable<void> {

--- a/src/services/nrk/NrkApi.ts
+++ b/src/services/nrk/NrkApi.ts
@@ -216,32 +216,38 @@ class _NrkApi extends ServiceApi {
 
 	updateItemFromHistory(item: ScrobbleItemValues, historyItem: NrkProgressItem): Promisable<void> {
 		item.watchedAt = historyItem.registeredAt ? Utils.unix(historyItem.registeredAt) : undefined;
-		item.progress = historyItem.progress === 'inProgress' ? historyItem.inProgress.percentage : 100;
+		item.progress = this.getProgress(historyItem);
+	}
+
+	private getProgress(historyItem: NrkProgressItem): number {
+		return historyItem.progress === 'inProgress' ? historyItem.inProgress.percentage : 100;
 	}
 
 	async parseHistoryItem(historyItem: NrkProgressItem): Promise<ScrobbleItem> {
 		const serviceId = this.id;
 		const id = historyItem.id;
 		const programInfo = historyItem._embedded.programs;
-		const programPage = await this.lookupNrkItem(programInfo._links.self.href);
-		const type = programPage._links.seriesPage !== undefined ? 'show' : 'movie';
+		let programPage: NrkProgramPage | null = null;
+		try {
+			programPage = await this.lookupNrkItem(programInfo._links.self.href);
+		} catch (err) {
+			// The program may have been removed from NRK - the history item still embeds
+			// enough information (the titles) to build a searchable item, so degrade
+			// gracefully instead of failing the whole history load
+			console.debug('[UTS] Failed to look up NRK program, using embedded titles', id, err);
+		}
 		const titleInfo = programInfo.titles;
-		//TODO This is a good point for having fallback-search items. Also this could be used to differenciate displaytitle and searchtitle.
-		const title = this.getTitle(programPage);
+		const title = programPage ? this.getTitle(programPage) : titleInfo.title;
 		const watchedAt = historyItem.registeredAt ? Utils.unix(historyItem.registeredAt) : undefined;
 
 		const baseItem: BaseItemValues = {
 			serviceId,
 			id,
 			title,
-			year: programPage.moreInformation.productionYear,
-			progress: historyItem.progress === 'inProgress' ? historyItem.inProgress.percentage : 100,
+			year: programPage?.moreInformation.productionYear,
+			progress: this.getProgress(historyItem),
 			watchedAt,
 		};
-
-		if (type === 'movie') {
-			return new MovieItem(baseItem);
-		}
 
 		/* Known formats:
 		 * S2 / 7. Episode Title
@@ -251,6 +257,19 @@ class _NrkApi extends ServiceApi {
 		const regExp =
 			/(?<fullStr>S(?<seasonStr>[0-9]+) [/] (?<episodeStr>[0-9]+)[.] (?<partialEpisodeTitle>.+))/g; //This captures Season number, episode number, and episode title.
 		const [matches] = [...titleInfo.subtitle.matchAll(regExp)];
+
+		// Without the program page, fall back to the subtitle format to detect episodes
+		const type = programPage
+			? programPage._links.seriesPage !== undefined
+				? 'show'
+				: 'movie'
+			: matches
+				? 'show'
+				: 'movie';
+
+		if (type === 'movie') {
+			return new MovieItem(baseItem);
+		}
 		let episodeTitle;
 		let season = 0;
 		let number = 0;

--- a/src/services/tv2-play/Tv2PlayApi.ts
+++ b/src/services/tv2-play/Tv2PlayApi.ts
@@ -276,12 +276,12 @@ class _Tv2PlayApi extends ServiceApi {
 			// Use historyItem.id as the identifier (asset.id was removed by TV2)
 			const assetId = historyItem.id;
 
-			// Try to get episode title from content response
-			// Episode title is in player.metainfo[1].text (metainfo[0] is "S1E2" format)
-			let episodeTitle = `Episode ${episodeNumber}`; // Fallback
-			if (contentResponse?.player?.metainfo?.[1]?.text) {
-				episodeTitle = contentResponse.player.metainfo[1].text;
-			}
+			// The asset title in the history response is the episode title, so the content
+			// response (player.metainfo[1].text) is only needed as a fallback
+			const episodeTitle =
+				historyItem.asset.title ||
+				contentResponse?.player?.metainfo?.[1]?.text ||
+				`Episode ${episodeNumber}`;
 
 			const values = {
 				serviceId: this.id,

--- a/src/services/tv2-play/Tv2PlayApi.ts
+++ b/src/services/tv2-play/Tv2PlayApi.ts
@@ -152,9 +152,7 @@ class _Tv2PlayApi extends ServiceApi {
 	}
 
 	async checkLogin() {
-		if (!this.isActivated) {
-			await this.activate();
-		}
+		await this.ensureActivated();
 		return !!this.session && this.session.profileName !== null;
 	}
 
@@ -319,8 +317,9 @@ class _Tv2PlayApi extends ServiceApi {
 		// Use the watched percentage directly from the API
 		if (contentInfo?.progress && typeof contentInfo.progress.watched === 'number') {
 			item.progress = contentInfo.progress.watched;
-		} else {
-			// Fallback to 100 if progress information is not available
+		} else if (!item.progress) {
+			// The progress lookup failed - keep any previously known progress instead of
+			// overwriting it, and only assume fully watched when nothing is known
 			item.progress = 100;
 		}
 

--- a/src/services/tv2-play/Tv2PlayApi.ts
+++ b/src/services/tv2-play/Tv2PlayApi.ts
@@ -84,6 +84,9 @@ interface Auth0TokenData {
 interface Tv2PlaySession {
 	accessToken: string;
 	refreshToken?: string;
+
+	// Unix timestamp in seconds
+	expiresAt?: number;
 }
 
 class _Tv2PlayApi extends ServiceApi {
@@ -93,6 +96,7 @@ class _Tv2PlayApi extends ServiceApi {
 	token: string;
 	isActivated: boolean;
 	pageSize = 10;
+	private tokenExpiresAt = 0;
 
 	authRequests = Requests;
 
@@ -116,8 +120,13 @@ class _Tv2PlayApi extends ServiceApi {
 		if (!sessionData || !sessionData.accessToken) {
 			throw new Error('Could not retrieve Auth0 access token from TV2 Play');
 		}
+		if (sessionData.expiresAt && Utils.unix() >= sessionData.expiresAt) {
+			// The page also only holds an expired token, so there is nothing fresher to pick up
+			throw new Error('The TV2 Play access token has expired');
+		}
 
 		this.token = sessionData.accessToken;
+		this.tokenExpiresAt = sessionData.expiresAt ?? 0;
 
 		this.authRequests = withHeaders({
 			Authorization: `Bearer ${this.token}`,
@@ -134,6 +143,16 @@ class _Tv2PlayApi extends ServiceApi {
 		};
 		this.isActivated = true;
 	}
+	/**
+	 * Re-activates when the access token has expired - the TV 2 Play page keeps a fresh
+	 * token in localStorage, so a new session injection picks it up.
+	 */
+	private async ensureActivated(): Promise<void> {
+		if (!this.isActivated || (this.tokenExpiresAt > 0 && Utils.unix() >= this.tokenExpiresAt)) {
+			await this.activate();
+		}
+	}
+
 	async checkLogin() {
 		if (!this.isActivated) {
 			await this.activate();
@@ -142,9 +161,7 @@ class _Tv2PlayApi extends ServiceApi {
 	}
 
 	async loadHistoryItems(): Promise<Tv2PlayHistoryItem[]> {
-		if (!this.isActivated) {
-			await this.activate();
-		}
+		await this.ensureActivated();
 
 		// Retrieve the history items
 		const responseText = await this.authRequests.send({
@@ -220,9 +237,7 @@ class _Tv2PlayApi extends ServiceApi {
 		year: number;
 		contentResponse?: TV2PlayContentResponse;
 	}> {
-		if (!this.isActivated) {
-			await this.activate();
-		}
+		await this.ensureActivated();
 
 		try {
 			const responseText = await this.authRequests.send({
@@ -315,9 +330,7 @@ class _Tv2PlayApi extends ServiceApi {
 	}
 
 	async getItem(path: string): Promise<ScrobbleItem> {
-		if (!this.isActivated) {
-			await this.activate();
-		}
+		await this.ensureActivated();
 
 		const responseText = await this.authRequests.send({
 			url: `https://ai.play.tv2.no/v4/content/path${path}`,
@@ -395,6 +408,7 @@ Shared.functionsToInject[`${Tv2PlayService.id}-session`] = (): Tv2PlaySession | 
 		return {
 			accessToken: auth0Data.body.access_token,
 			refreshToken: auth0Data.body.refresh_token,
+			expiresAt: auth0Data.expiresAt,
 		};
 	} catch (_error) {
 		return null;

--- a/src/services/tv2-play/Tv2PlayApi.ts
+++ b/src/services/tv2-play/Tv2PlayApi.ts
@@ -29,6 +29,16 @@ interface Tv2PlayMovieHistoryItem {
 
 export type Tv2PlayHistoryItem = Tv2PlayMovieHistoryItem | Tv2PlayEpisodeHistoryItem;
 
+export type Tv2PlayHistoryItemWithContent = Tv2PlayHistoryItem & {
+	contentInfo?: Tv2PlayContentInfo;
+};
+
+interface Tv2PlayContentInfo {
+	progress: TV2PlayProgress | null;
+	year: number;
+	contentResponse?: TV2PlayContentResponse;
+}
+
 // Content API response types
 interface TV2PlayProgress {
 	position?: number;
@@ -162,19 +172,30 @@ class _Tv2PlayApi extends ServiceApi {
 		return historyItem.id.toString();
 	}
 
-	async convertHistoryItems(historyItems: Tv2PlayHistoryItem[]) {
+	/**
+	 * Enriches history items with content info (progress, year, and episode title for episodes)
+	 * before cached items and new items take separate paths, so that
+	 * `updateItemFromHistory()` can keep the progress of cached items up-to-date.
+	 */
+	prepareHistoryItems(
+		historyItems: Tv2PlayHistoryItem[]
+	): Promise<Tv2PlayHistoryItemWithContent[]> {
+		return Promise.all(
+			historyItems.map(async (historyItem) => ({
+				...historyItem,
+				contentInfo: await this.getProgressForItem(historyItem.asset.path),
+			}))
+		);
+	}
+
+	async convertHistoryItems(historyItems: Tv2PlayHistoryItemWithContent[]) {
 		const promises = historyItems.map(async (historyItem) => {
-			// Fetch content info (progress, year, and episode title for episodes)
-			let contentInfo;
-			try {
-				contentInfo = await this.getProgressForItem(historyItem.asset.path);
-			} catch (error) {
-				console.error('Failed to get progress for item:', historyItem.asset.path, error);
-			}
+			const item = await this.parseHistoryItemWithTitle(
+				historyItem,
+				historyItem.contentInfo?.contentResponse
+			);
 
-			const item = await this.parseHistoryItemWithTitle(historyItem, contentInfo?.contentResponse);
-
-			await this.updateItemFromHistory(item, historyItem, contentInfo);
+			await this.updateItemFromHistory(item, historyItem);
 			return item;
 		});
 
@@ -274,9 +295,9 @@ class _Tv2PlayApi extends ServiceApi {
 
 	updateItemFromHistory(
 		item: ScrobbleItemValues,
-		historyItem: Tv2PlayHistoryItem,
-		contentInfo?: { progress: TV2PlayProgress | null; year: number }
+		historyItem: Tv2PlayHistoryItemWithContent
 	): Promisable<void> {
+		const { contentInfo } = historyItem;
 		item.watchedAt = historyItem.date ? Utils.unix(historyItem.date) : undefined;
 
 		// Use the watched percentage directly from the API

--- a/src/services/tv2-play/Tv2PlayApi.ts
+++ b/src/services/tv2-play/Tv2PlayApi.ts
@@ -90,8 +90,7 @@ interface Tv2PlaySession {
 }
 
 class _Tv2PlayApi extends ServiceApi {
-	HISTORY_URL: string;
-	TOKEN_URL: string;
+	API_URL: string;
 	PROFILE_URL: string;
 	token: string;
 	isActivated: boolean;
@@ -102,8 +101,7 @@ class _Tv2PlayApi extends ServiceApi {
 
 	constructor() {
 		super(Tv2PlayService.id);
-		this.HISTORY_URL = 'https://ai.play.tv2.no/v4/viewinghistory/?start=0&size=10';
-		this.TOKEN_URL = 'https://id.tv2.no/oauth/token';
+		this.API_URL = 'https://ai.play.tv2.no/v4';
 		this.PROFILE_URL = 'https://api.play.tv2.no/user/';
 		this.token = '';
 		this.isActivated = false;
@@ -160,15 +158,16 @@ class _Tv2PlayApi extends ServiceApi {
 		return !!this.session && this.session.profileName !== null;
 	}
 
-	async loadHistoryItems(): Promise<Tv2PlayHistoryItem[]> {
+	async loadHistoryItems(cancelKey = 'default'): Promise<Tv2PlayHistoryItem[]> {
 		await this.ensureActivated();
 
 		// Retrieve the history items
 		const responseText = await this.authRequests.send({
-			url: `https://ai.play.tv2.no/v4/viewinghistory/?start=${
+			url: `${this.API_URL}/viewinghistory/?start=${
 				this.nextHistoryPage * this.pageSize
 			}&size=${this.pageSize}`,
 			method: 'GET',
+			cancelKey,
 		});
 		const historyItems = JSON.parse(responseText) as Tv2PlayHistoryItem[];
 
@@ -241,7 +240,7 @@ class _Tv2PlayApi extends ServiceApi {
 
 		try {
 			const responseText = await this.authRequests.send({
-				url: `https://ai.play.tv2.no/v4/content/path${path}`,
+				url: `${this.API_URL}/content/path${path}`,
 				method: 'GET',
 			});
 			const responseJson = JSON.parse(responseText) as TV2PlayContentResponse;
@@ -252,7 +251,7 @@ class _Tv2PlayApi extends ServiceApi {
 				contentResponse: responseJson,
 			};
 		} catch (error) {
-			console.error('Failed to fetch progress for item:', path, error);
+			console.debug('[UTS] Failed to fetch progress for TV 2 Play item', path, error);
 			return { progress: null, year: 0 };
 		}
 	}
@@ -333,7 +332,7 @@ class _Tv2PlayApi extends ServiceApi {
 		await this.ensureActivated();
 
 		const responseText = await this.authRequests.send({
-			url: `https://ai.play.tv2.no/v4/content/path${path}`,
+			url: `${this.API_URL}/content/path${path}`,
 			method: 'GET',
 		});
 		const responseJson = JSON.parse(responseText) as TV2PlayContentResponse;

--- a/src/services/tv2-play/Tv2PlayApi.ts
+++ b/src/services/tv2-play/Tv2PlayApi.ts
@@ -273,7 +273,9 @@ class _Tv2PlayApi extends ServiceApi {
 				? parseInt(episodeMatch.groups.episode, 10)
 				: 0;
 
-			// Use historyItem.id as the identifier (asset.id was removed by TV2)
+			// Use historyItem.id as the identifier (asset.id was removed by TV2). It holds the
+			// same value as the content response's player.asset_id, which getItem() uses for
+			// scrobbled items, so corrections are shared between scrobbling and history sync.
 			const assetId = historyItem.id;
 
 			// The asset title in the history response is the episode title, so the content

--- a/src/services/viaplay/ViaplayApi.ts
+++ b/src/services/viaplay/ViaplayApi.ts
@@ -91,7 +91,7 @@ export interface ViaplayEpisode extends ViaplayProductBase {
 			episodeTitle: string; //Sometimes prefixed with episodeNumber
 			title: string; //Show title
 			season: {
-				seasonNumber: 1;
+				seasonNumber: number;
 			};
 		};
 	};

--- a/src/services/viaplay/ViaplayApi.ts
+++ b/src/services/viaplay/ViaplayApi.ts
@@ -246,7 +246,14 @@ class _ViaplayApi extends ServiceApi {
 	updateItemFromHistory(item: ScrobbleItemValues, historyItem: ViaplayProduct): Promisable<void> {
 		const progressInfo = historyItem.user.progress;
 		item.watchedAt = progressInfo?.updated ? Utils.unix(progressInfo.updated) : undefined;
-		item.progress = progressInfo?.elapsedPercent || 0;
+		item.progress = this.getProgress(historyItem);
+	}
+
+	private getProgress(product: ViaplayProduct): number {
+		const progressInfo = product.user.progress;
+		// Fall back to the watched flag only when the percentage is missing, so an item
+		// marked as watched without an elapsed percentage isn't treated as unwatched
+		return progressInfo?.elapsedPercent ?? (progressInfo?.watched ? 100 : 0);
 	}
 
 	parseViaplayProduct(product: ViaplayProduct): ScrobbleItem {
@@ -254,7 +261,7 @@ class _ViaplayApi extends ServiceApi {
 		const serviceId = this.id;
 		const year = product.content.production.year;
 		const progressInfo = product.user.progress;
-		const progress = progressInfo?.elapsedPercent || 0;
+		const progress = this.getProgress(product);
 		const watchedAt = progressInfo?.updated ? Utils.unix(progressInfo.updated) : undefined;
 		const id = product.system.guid;
 		if (product.type === 'episode') {


### PR DESCRIPTION
- **fix: keep TV 2 Play progress accurate for cached history items**
- **fix: re-activate TV 2 Play when the access token has expired**
- **chore: clean up TV 2 Play API internals**
- **fix: don't fail the whole NRK history load when one program lookup fails**
- **fix: use the watched flag as fallback for Viaplay items without an elapsed percentage**
- **fix: re-activate NRK when the access token has expired**
- **fix: load NRK program pages sequentially during history conversion**
- **chore: type Viaplay season numbers as number instead of the literal 1**
- **fix: use the asset title from the TV 2 Play history as the episode title**
- **docs: note that TV 2 Play history ids match the scrobbler's asset ids**
