### PR TITLE
Crunchyroll movie matching

### DIFF
--- a/src/services/crunchyroll/CrunchyrollApi.ts
+++ b/src/services/crunchyroll/CrunchyrollApi.ts
@@ -34,6 +34,9 @@ export interface CrunchyrollHistoryItem {
 	panel: {
 		title: string;
 		episode_metadata: CrunchyrollEpisodeMetadata;
+		images?: {
+			thumbnail?: CrunchyrollThumbnail[][];
+		};
 	};
 }
 
@@ -50,6 +53,13 @@ export interface CrunchyrollEpisodeMetadata {
 	series_title: string;
 	series_slug_title?: string;
 	duration_ms: number;
+}
+
+export interface CrunchyrollThumbnail {
+	height: number;
+	source: string;
+	type: string;
+	width: number;
 }
 
 class _CrunchyrollApi extends ServiceApi {
@@ -177,12 +187,16 @@ class _CrunchyrollApi extends ServiceApi {
 		for (const historyItem of historyItems) {
 			const metadata = historyItem.panel.episode_metadata;
 			const title = this.getNormalizedTitle(historyItem);
+			const thumbnail = historyItem.panel.images?.thumbnail
+				?.find((o) => o.length > 0)
+				?.find((t) => !!t.source);
 
 			if (this.isMovie(historyItem)) {
 				const item = new MovieItem({
 					id: historyItem.id,
 					serviceId: this.id,
 					title: title,
+					imageUrl: thumbnail?.source,
 					year: new Date(metadata.episode_air_date).getUTCFullYear(),
 					watchedAt: Utils.unix(historyItem.date_played),
 					progress: historyItem.fully_watched
@@ -195,6 +209,7 @@ class _CrunchyrollApi extends ServiceApi {
 					id: historyItem.id,
 					serviceId: this.id,
 					title: title,
+					imageUrl: thumbnail?.source,
 					number: metadata.episode_number || 0,
 					// season numbering is often not aligned with official seasons
 					// check against slug to receive more aligned season number

--- a/src/services/crunchyroll/CrunchyrollApi.ts
+++ b/src/services/crunchyroll/CrunchyrollApi.ts
@@ -48,6 +48,7 @@ export interface CrunchyrollEpisodeMetadata {
 	season_title: string;
 	season_slug_title?: string;
 	series_title: string;
+	series_slug_title?: string;
 	duration_ms: number;
 }
 
@@ -60,6 +61,9 @@ class _CrunchyrollApi extends ServiceApi {
 	DEVICE_NAME: string;
 	isActivated: boolean;
 	session: CrunchyrollSession | null = null;
+
+	movieRegex: RegExp = /(?:^|-)movies?|mov(?:-|$)/i;
+	dubSubSuffix: RegExp = / \((?:\w+ )?(?:Dub|Dubbed|Sub|Subbed|Subtitled)\)/;
 
 	authRequests = Requests;
 
@@ -169,18 +173,12 @@ class _CrunchyrollApi extends ServiceApi {
 
 	convertHistoryItems(historyItems: CrunchyrollHistoryItem[]): Promise<ScrobbleItem[]> {
 		const items: ScrobbleItem[] = [];
-		const dubSubSuffix = / \((?:\w+ )?(?:Dub|Dubbed|Sub|Subbed|Subtitled)\)/;
 
 		for (const historyItem of historyItems) {
 			const metadata = historyItem.panel.episode_metadata;
-			const isMovie =
-				metadata.season_title?.includes('Movie') ||
-				historyItem.panel.title === 'Movie' ||
-				metadata.episode_number?.toString() === 'Movie';
+			const title = this.getNormalizedTitle(historyItem);
 
-			const title = historyItem.panel.title.replace(dubSubSuffix, '');
-
-			if (isMovie) {
+			if (this.isMovie(historyItem)) {
 				const item = new MovieItem({
 					id: historyItem.id,
 					serviceId: this.id,
@@ -196,10 +194,7 @@ class _CrunchyrollApi extends ServiceApi {
 				const item = new EpisodeItem({
 					id: historyItem.id,
 					serviceId: this.id,
-					title:
-						title.toLowerCase() === 'episode'
-							? `${title} ${metadata.episode || metadata.sequence_number}`
-							: title,
+					title: title,
 					number: metadata.episode_number || 0,
 					// season numbering is often not aligned with official seasons
 					// check against slug to receive more aligned season number
@@ -239,6 +234,32 @@ class _CrunchyrollApi extends ServiceApi {
 		}
 		const { season } = matches.groups;
 		return Number.parseInt(season, 10);
+	}
+
+	isMovie(historyItem: CrunchyrollHistoryItem): boolean {
+		const metadata = historyItem.panel.episode_metadata;
+		return (
+			(!!metadata.season_title && metadata.season_title.toLowerCase().includes('movie')) ||
+			historyItem.panel.title.toLowerCase() === 'movie' ||
+			metadata.episode_number === null ||
+			this.movieRegex.test(metadata.series_slug_title ?? '') ||
+			this.movieRegex.test(metadata.season_slug_title ?? '')
+		);
+	}
+
+	getNormalizedTitle(historyItem: CrunchyrollHistoryItem) {
+		const title = historyItem.panel.title.replace(this.dubSubSuffix, '');
+		const metadata = historyItem.panel.episode_metadata;
+		if (title.toLowerCase() === 'episode') {
+			return `${title} ${metadata.episode || metadata.sequence_number}`;
+		}
+		if (title.toLowerCase() === 'movie' || title.trim().length === 0) {
+			return (
+				metadata.season_title.replace(this.dubSubSuffix, '') ||
+				metadata.series_title.replace(this.dubSubSuffix, '')
+			);
+		}
+		return title;
 	}
 
 	parseJsonWithDates<T>(text: string, dateFieldNames: string[]): T {

--- a/src/services/crunchyroll/CrunchyrollApi.ts
+++ b/src/services/crunchyroll/CrunchyrollApi.ts
@@ -45,13 +45,13 @@ export interface CrunchyrollEpisodeMetadata {
 	season_number: number;
 	season_id: string;
 	episode: string;
-	episode_number?: number;
-	sequence_number?: number;
+	episode_number: number;
+	sequence_number: number;
 	episode_air_date: Date;
 	season_title: string;
-	season_slug_title?: string;
+	season_slug_title: string;
 	series_title: string;
-	series_slug_title?: string;
+	series_slug_title: string;
 	duration_ms: number;
 }
 
@@ -72,7 +72,7 @@ class _CrunchyrollApi extends ServiceApi {
 	isActivated: boolean;
 	session: CrunchyrollSession | null = null;
 
-	movieRegex: RegExp = /(?:^|-)movies?|mov(?:-|$)/i;
+	movieRegex: RegExp = /(?:^|-)(?:movies?|mov)(?:-|$)/i;
 	dubSubSuffix: RegExp = / \((?:\w+ )?(?:Dub|Dubbed|Sub|Subbed|Subtitled)\)/;
 
 	authRequests = Requests;
@@ -254,11 +254,11 @@ class _CrunchyrollApi extends ServiceApi {
 	isMovie(historyItem: CrunchyrollHistoryItem): boolean {
 		const metadata = historyItem.panel.episode_metadata;
 		return (
-			(!!metadata.season_title && metadata.season_title.toLowerCase().includes('movie')) ||
+			metadata.season_title.toLowerCase().includes('movie') ||
 			historyItem.panel.title.toLowerCase() === 'movie' ||
 			metadata.episode_number === null ||
-			this.movieRegex.test(metadata.series_slug_title ?? '') ||
-			this.movieRegex.test(metadata.season_slug_title ?? '')
+			this.movieRegex.test(metadata.series_slug_title) ||
+			this.movieRegex.test(metadata.season_slug_title)
 		);
 	}
 


### PR DESCRIPTION
Check for `movie(s)` in series/season slug for increased movie matching. Movie titles are sometimes only present as season or show title.
If this matching still misses some movies, it could be matched against localized versions of `movie` in some future versions.

Also add thumbnails for the matching preview.