### PR TITLE
fix(adn): receive items from adn-api in distribution language

### DIFF
--- a/src/services/adn/AdnApi.ts
+++ b/src/services/adn/AdnApi.ts
@@ -189,6 +189,7 @@ class _AdnApi extends ServiceApi {
 			headers: {
 				Authorization: `Bearer ${this.session.auth.accessToken}`,
 				'x-target-distribution': `${this.lang}`,
+				'accept-language': `${this.lang}`,
 				'x-profile-id': `${this.session.profileId}`,
 			},
 			method: 'GET',


### PR DESCRIPTION
Found a small misalignment.

ADN respects the `accept-language` header when querying the API. Since `x-target-distribution` only supplies data for a specific country, the show & episode titles most often have generic names (e.g. "Some Show - Episode 1") in all languages other than the distribution language.

Sending the `x-target-distribution` as `accept-language` too solves this problem.