### PR TITLE
Fix history cache hiding recently watched items and auto-sync advancing lastSync on failure

### DIFF
--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -170,7 +170,10 @@ export abstract class ServiceApi {
 					responseItems = await this.loadHistoryItems(cancelKey);
 					if (!this.hasCheckedHistoryCache) {
 						this.hasCheckedHistoryCache = true;
-						if (historyCache.items.length > 0) {
+						if (
+							historyCache.items.length > 0 &&
+							this.isHistoryCacheForCurrentProfile(historyCache)
+						) {
 							const reconciled = await this.reconcileHistoryCache(
 								responseItems,
 								historyCache,
@@ -186,6 +189,7 @@ export abstract class ServiceApi {
 							items: [],
 						};
 					}
+					historyCache.profileName = this.session?.profileName;
 					historyCache.nextPage = this.nextHistoryPage;
 					historyCache.nextUrl = this.nextHistoryUrl;
 					historyCache.items.push(...responseItems);
@@ -274,6 +278,23 @@ export abstract class ServiceApi {
 			throw err;
 		}
 		return items;
+	}
+
+	/**
+	 * Whether the cached history was written for the profile that is currently logged in.
+	 *
+	 * History item IDs are often content IDs (e.g. Netflix `movieID`), so two profiles that watched the
+	 * same title would otherwise match during reconciliation and mix their histories. When both the cache
+	 * and the current session know the profile, they must agree; if either is unknown (service without
+	 * profiles, or a cache written before this field existed), fall back to ID-based reconciliation.
+	 */
+	private isHistoryCacheForCurrentProfile(historyCache: HistoryCache): boolean {
+		const cachedProfile = historyCache.profileName;
+		const currentProfile = this.session?.profileName;
+		if (cachedProfile == null || currentProfile == null) {
+			return true;
+		}
+		return cachedProfile === currentProfile;
 	}
 
 	/**

--- a/src/apis/ServiceApi.ts
+++ b/src/apis/ServiceApi.ts
@@ -1,7 +1,7 @@
 import { Suggestion } from '@apis/CorrectionApi';
 import { TraktSearch } from '@apis/TraktSearch';
 import { TraktSync } from '@apis/TraktSync';
-import { Cache, CacheItems } from '@common/Cache';
+import { Cache, CacheItems, HistoryCache } from '@common/Cache';
 import { RequestError } from '@common/RequestError';
 import { Shared } from '@common/Shared';
 import { createScrobbleItem, ScrobbleItem, ScrobbleItemValues } from '@models/Item';
@@ -169,30 +169,22 @@ export abstract class ServiceApi {
 				} else if (!this.hasReachedHistoryEnd) {
 					responseItems = await this.loadHistoryItems(cancelKey);
 					if (!this.hasCheckedHistoryCache) {
-						let firstItem: ScrobbleItemValues | null = null;
+						this.hasCheckedHistoryCache = true;
 						if (historyCache.items.length > 0) {
-							const historyItemId = `${this.id}_${this.getHistoryItemId(historyCache.items[0])}`;
-							const itemId = caches.historyItemsToItems.get(historyItemId);
-							if (itemId) {
-								firstItem = caches.items.get(itemId) ?? null;
+							const reconciled = await this.reconcileHistoryCache(
+								responseItems,
+								historyCache,
+								cancelKey
+							);
+							responseItems = reconciled.items;
+							if (reconciled.reusedCache) {
+								this.nextHistoryPage = historyCache.nextPage ?? this.nextHistoryPage;
+								this.nextHistoryUrl = historyCache.nextUrl ?? this.nextHistoryUrl;
 							}
 						}
-						if (
-							responseItems.length > 0 &&
-							firstItem &&
-							this.isNewHistoryItem(responseItems[0], firstItem.watchedAt ?? 0, firstItem.id ?? '')
-						) {
-							historyCache = {
-								items: [],
-							};
-						}
-						this.nextHistoryPage = historyCache.nextPage ?? this.nextHistoryPage;
-						this.nextHistoryUrl = historyCache.nextUrl ?? this.nextHistoryUrl;
-						if (historyCache.items.length > 0) {
-							responseItems = historyCache.items;
-							historyCache.items = [];
-						}
-						this.hasCheckedHistoryCache = true;
+						historyCache = {
+							items: [],
+						};
 					}
 					historyCache.nextPage = this.nextHistoryPage;
 					historyCache.nextUrl = this.nextHistoryUrl;
@@ -283,6 +275,75 @@ export abstract class ServiceApi {
 		}
 		return items;
 	}
+
+	/**
+	 * Reconciles the cached history with the fresh first page returned by the service.
+	 *
+	 * The cache stores a contiguous prefix of the history, from the newest item known at the time down to
+	 * `nextUrl`/`nextPage`, so that re-opening the history page does not re-request every page (and every
+	 * item lookup) from the service - which matters for rate-limited APIs.
+	 *
+	 * Whether the cache is still valid is decided by history item IDs, not by watched dates: pages are
+	 * fetched until an item that is already in the cache is found. Everything before that item is new and
+	 * gets prepended, the cached items from that point on are reused (with fresh copies where the service
+	 * returned them, so updated progress/dates win). If no cached item is found within a few pages, the
+	 * cache is considered stale (e.g. profile switch, history cleared) and the fresh items replace it.
+	 *
+	 * Returns `reusedCache: true` when pagination should continue from the cached `nextUrl`/`nextPage`.
+	 */
+	private async reconcileHistoryCache(
+		firstPage: unknown[],
+		historyCache: HistoryCache,
+		cancelKey: string
+	): Promise<{ items: unknown[]; reusedCache: boolean }> {
+		const cachedIndexes = new Map<string, number>();
+		for (const [index, cachedItem] of historyCache.items.entries()) {
+			const id = this.getHistoryItemId(cachedItem);
+			if (!cachedIndexes.has(id)) {
+				cachedIndexes.set(id, index);
+			}
+		}
+
+		const freshItems: unknown[] = [];
+		let page = firstPage;
+		let pagesFetched = 1;
+		for (;;) {
+			let matchIndex = -1;
+			for (const item of page) {
+				const index = cachedIndexes.get(this.getHistoryItemId(item));
+				if (typeof index !== 'undefined') {
+					matchIndex = index;
+					break;
+				}
+			}
+			freshItems.push(...page);
+			if (matchIndex >= 0) {
+				if (this.hasReachedHistoryEnd) {
+					// The fresh pages already cover the whole history, nothing to reuse
+					return { items: freshItems, reusedCache: false };
+				}
+				const freshIds = new Set(freshItems.map((item) => this.getHistoryItemId(item)));
+				const reusedItems = historyCache.items
+					.slice(matchIndex)
+					.filter((item) => !freshIds.has(this.getHistoryItemId(item)));
+				return { items: [...freshItems, ...reusedItems], reusedCache: true };
+			}
+			if (this.hasReachedHistoryEnd || pagesFetched >= ServiceApi.MAX_CACHE_RECONCILE_PAGES) {
+				break;
+			}
+			page = await this.loadHistoryItems(cancelKey);
+			pagesFetched += 1;
+		}
+
+		// No overlap with the cache within the pages fetched - treat the cache as stale
+		return { items: freshItems, reusedCache: false };
+	}
+
+	/**
+	 * How many pages to look through for an item that is already cached before giving up on the cache.
+	 * Keeps the number of requests bounded when a lot has been watched since the last visit.
+	 */
+	private static readonly MAX_CACHE_RECONCILE_PAGES = 5;
 
 	reset(): void {
 		this.leftoverHistoryItems = [];

--- a/src/common/AutoSync.ts
+++ b/src/common/AutoSync.ts
@@ -82,6 +82,7 @@ class _AutoSync {
 
 		for (const service of services) {
 			let wasCanceled = false;
+			let hasLoadedHistory = false;
 
 			const serviceValue = Shared.storage.options.services[service.id];
 			let items: ScrobbleItem[] = [];
@@ -94,6 +95,7 @@ class _AutoSync {
 
 			try {
 				await api.loadHistory(Infinity, serviceValue.lastSync, serviceValue.lastSyncId, 'autoSync');
+				hasLoadedHistory = true;
 
 				items = store.data.items.filter(
 					(item) => item.progress >= Shared.storage.syncOptions.minPercentageWatched
@@ -133,7 +135,10 @@ class _AutoSync {
 			api.reset();
 			await store.resetData();
 
-			if (!wasCanceled) {
+			// Only move `lastSync` forward when the history was actually loaded. If loading failed,
+			// nothing was seen, and advancing the date would hide everything watched since the
+			// previous sync behind the last sync date without it ever being synced.
+			if (!wasCanceled && hasLoadedHistory) {
 				const partialServiceValue = partialOptions.services?.[service.id] || {};
 				partialServiceValue.lastSync = now;
 				if (items[0]?.id) {

--- a/src/common/Cache.ts
+++ b/src/common/Cache.ts
@@ -49,6 +49,12 @@ export type CacheKeysToStorageKeys = {
 export interface HistoryCache {
 	nextPage?: number;
 	nextUrl?: string;
+	/**
+	 * Profile the cached history belongs to, when the service exposes one. Used to discard the cache
+	 * when the user switches profile, since history item IDs alone (often content IDs) can match
+	 * across profiles.
+	 */
+	profileName?: string | null;
 	items: unknown[];
 }
 


### PR DESCRIPTION
## Problem

Opening the history page for a service showed only old items together with the message *"No more items since the last sync date"*, even though recently watched items were missing. After a while `lastSync` had also moved forward without those items ever being synced, so they ended up behind "Continue loading" for good.

## Root cause

`ServiceApi.loadHistory` caches the raw history pages (`history` cache) so that re-opening the page does not re-request every page and every item lookup from the service - important for rate-limited APIs. The cache was only discarded when:

1. the cached top item could be resolved via `historyItemsToItems` → `items`, **and**
2. the fresh top item was newer than it.

Those two caches drift apart: `history` is rewritten on every load (so it never expires), while the `items` entry for the top item is only written when that item passes the `lastSync` filter - which it never does again once it *is* the last synced item. After 24h `Cache.check()` deletes it, step 1 fails, the check silently passes, and the stale cache wins forever. The fresh first page was fetched and then thrown away.

`AutoSync` then loads through the same stuck cache, finds nothing, and still sets `lastSync = now`, hiding everything watched in between behind the last sync date without syncing it.

This has been latent since the history cache was introduced in #85 (2021).

## Fix

- **`ServiceApi.loadHistory`**: reconcile the cache by **history item IDs** instead of watched dates. Pages are fetched until an item already in the cache is found; everything before it is new and gets prepended, the rest of the cache is reused (fresh copies win, so updated progress/dates are picked up). If no cached item is found within 5 pages (profile switch, cleared history) the cache is treated as stale and the fresh items replace it. The first page was already fetched fresh before, so the common case costs no extra requests, and the cache keeps protecting against rate limits when scrolling back.
- **`AutoSync`**: only advance `lastSync` when the history was actually loaded.

Fixes #217
Fixes #347
Fixes #481

---
Investigated and implemented together with Claude (Anthropic).
